### PR TITLE
Add Python tests and improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,12 @@ npm run build
 ```
 
 Releases are also created automatically when pushing a tag (`v1.0.0`).
+
+## 🧪 Running Tests
+
+The project uses `pytest` for its test-suite. After installing the Python
+dependencies you can execute the tests via:
+
+```bash
+pytest
+```

--- a/app/calserver_api.py
+++ b/app/calserver_api.py
@@ -1,9 +1,39 @@
+"""Small wrapper around the calServer REST API."""
+
 import requests
 from typing import Any, Dict
 
 
-def fetch_calibration_data(base_url: str, username: str, password: str, api_key: str, filter_json: Dict[str, Any]) -> Dict[str, Any]:
-    """Fetch calibration data from calServer API."""
+def fetch_calibration_data(
+    base_url: str,
+    username: str,
+    password: str,
+    api_key: str,
+    filter_json: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Fetch calibration information from the API.
+
+    The function performs a ``GET`` request against ``/api/calibration`` and
+    returns the parsed JSON content of the response.
+
+    Parameters
+    ----------
+    base_url:
+        Base URL of the calServer instance.
+    username:
+        User name for authentication.
+    password:
+        Password for authentication.
+    api_key:
+        Additional API key to use.
+    filter_json:
+        JSON payload used as a query filter.
+
+    Returns
+    -------
+    dict
+        Parsed JSON content of the successful API response.
+    """
     params = {
         'username': username,
         'password': password,

--- a/app/label_templates.py
+++ b/app/label_templates.py
@@ -1,3 +1,5 @@
+"""Functions for rendering device and calibration label images."""
+
 from PIL import Image, ImageDraw, ImageFont
 from .qrcode_utils import generate_qr_code
 
@@ -5,21 +7,34 @@ FONT = ImageFont.load_default()
 
 
 def device_label(name: str, device_id: str) -> Image.Image:
-    img = Image.new('RGB', (400, 200), color='white')
+    """Create a label image for a device.
+
+    The label contains the device name, its identifier and a QR code
+    encoding the identifier.
+    """
+
+    img = Image.new("RGB", (400, 200), color="white")
     draw = ImageDraw.Draw(img)
-    draw.text((10, 10), name, font=FONT, fill='black')
-    draw.text((10, 50), f"ID: {device_id}", font=FONT, fill='black')
+    draw.text((10, 10), name, font=FONT, fill="black")
+    draw.text((10, 50), f"ID: {device_id}", font=FONT, fill="black")
     qr = generate_qr_code(device_id, size=100)
     img.paste(qr, (280, 10))
     return img
 
 
 def calibration_label(date: str, status: str, cert: str, qr_data: str) -> Image.Image:
-    img = Image.new('RGB', (400, 200), color='white')
+    """Create a calibration label image.
+
+    The label shows calibration date, status and certificate number. The
+    provided ``qr_data`` is encoded into a QR code and placed on the right
+    side of the label.
+    """
+
+    img = Image.new("RGB", (400, 200), color="white")
     draw = ImageDraw.Draw(img)
-    draw.text((10, 10), f"Date: {date}", font=FONT, fill='black')
-    draw.text((10, 50), f"Status: {status}", font=FONT, fill='black')
-    draw.text((10, 90), f"Cert: {cert}", font=FONT, fill='black')
+    draw.text((10, 10), f"Date: {date}", font=FONT, fill="black")
+    draw.text((10, 50), f"Status: {status}", font=FONT, fill="black")
+    draw.text((10, 90), f"Cert: {cert}", font=FONT, fill="black")
     qr = generate_qr_code(qr_data, size=100)
     img.paste(qr, (280, 10))
     return img

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,5 @@
+"""Streamlit based user interface for printing calibration labels."""
+
 import json
 import streamlit as st
 from PIL import Image
@@ -8,6 +10,8 @@ from .print_utils import list_printers, print_label
 
 
 def main():
+    """Run the interactive Streamlit application."""
+
     st.title("calServer Labeltool")
 
     base_url = st.text_input("API Base URL", "https://calserver.example.com")

--- a/app/print_utils.py
+++ b/app/print_utils.py
@@ -1,3 +1,5 @@
+"""Helpers for listing printers and printing images across platforms."""
+
 import platform
 from typing import List
 from PIL import Image
@@ -13,6 +15,8 @@ else:
 
 
 def list_printers() -> List[str]:
+    """Return a list of available printer names."""
+
     if platform.system() == 'Windows' and win32print:
         return [p[2] for p in win32print.EnumPrinters(2)]
     elif platform.system() in ('Linux', 'Darwin') and cups:
@@ -22,6 +26,12 @@ def list_printers() -> List[str]:
 
 
 def print_label(image: Image.Image, printer_name: str) -> None:
+    """Send the given image to ``printer_name``.
+
+    The implementation handles Windows and CUPS based systems. For other
+    platforms a ``RuntimeError`` is raised.
+    """
+
     if platform.system() == 'Windows' and win32print:
         import tempfile
         tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.bmp')

--- a/app/qrcode_utils.py
+++ b/app/qrcode_utils.py
@@ -1,8 +1,26 @@
+"""Utility helpers for creating QR codes as images."""
+
 import qrcode
 from PIL import Image
 
 
 def generate_qr_code(data: str, size: int = 200) -> Image.Image:
+    """Return a QR code image containing ``data``.
+
+    Parameters
+    ----------
+    data:
+        The text that should be encoded in the QR code.
+    size:
+        Width and height of the resulting image in pixels. Defaults to
+        ``200``.
+
+    Returns
+    -------
+    PIL.Image.Image
+        An image object containing the QR code.
+    """
+
     qr = qrcode.QRCode(box_size=10, border=2)
     qr.add_data(data)
     qr.make(fit=True)

--- a/tests/test_calserver_api.py
+++ b/tests/test_calserver_api.py
@@ -1,0 +1,35 @@
+import builtins
+import importlib
+from types import SimpleNamespace
+
+import sys
+
+# Provide a minimal 'requests' module for import
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+    def raise_for_status(self):
+        pass
+    def json(self):
+        return self._data
+
+def dummy_get(url, params=None, json=None, timeout=10):
+    return DummyResponse({"result": "ok", "params": params, "json": json})
+
+requests_mod = SimpleNamespace(get=dummy_get)
+sys.modules['requests'] = requests_mod
+
+calserver_api = importlib.import_module('app.calserver_api')
+
+
+def test_fetch_calibration_data():
+    data = calserver_api.fetch_calibration_data(
+        "http://example.com",
+        "user",
+        "pass",
+        "key",
+        {"foo": 1},
+    )
+    assert data["result"] == "ok"
+    assert data["params"]["username"] == "user"
+    assert data["json"] == {"foo": 1}

--- a/tests/test_list_printers.py
+++ b/tests/test_list_printers.py
@@ -1,0 +1,24 @@
+import importlib
+import sys
+import types
+
+# Prepare stub PIL modules since print_utils requires them
+pil_mod = types.ModuleType('PIL')
+pil_image_mod = types.ModuleType('PIL.Image')
+class DummyImage:
+    pass
+pil_image_mod.Image = DummyImage
+pil_mod.Image = pil_image_mod
+sys.modules['PIL'] = pil_mod
+sys.modules['PIL.Image'] = pil_image_mod
+sys.modules['win32print'] = types.ModuleType('win32print')
+sys.modules['cups'] = types.ModuleType('cups')
+
+print_utils = importlib.import_module('app.print_utils')
+
+
+def test_list_printers_unknown(monkeypatch):
+    monkeypatch.setattr(print_utils.platform, 'system', lambda: 'Other')
+    assert print_utils.list_printers() == []
+
+

--- a/tests/test_print_utils.py
+++ b/tests/test_print_utils.py
@@ -1,0 +1,29 @@
+import importlib
+import sys
+import types
+import pytest
+
+# Stub PIL module for import
+class DummyImage:
+    def save(self, path):
+        pass
+
+pil_mod = types.ModuleType('PIL')
+pil_image_mod = types.ModuleType('PIL.Image')
+pil_image_mod.Image = DummyImage
+pil_mod.Image = pil_image_mod
+sys.modules['PIL'] = pil_mod
+sys.modules['PIL.Image'] = pil_image_mod
+
+# Stub cups and win32print modules
+sys.modules['cups'] = types.ModuleType('cups')
+sys.modules['win32print'] = types.ModuleType('win32print')
+
+print_utils = importlib.import_module('app.print_utils')
+
+
+def test_print_label_unsupported(monkeypatch):
+    monkeypatch.setattr(print_utils.platform, 'system', lambda: 'Other')
+    with pytest.raises(RuntimeError):
+        print_utils.print_label(DummyImage(), 'dummy')
+

--- a/tests/test_qrcode_utils.py
+++ b/tests/test_qrcode_utils.py
@@ -1,0 +1,42 @@
+import importlib
+import sys
+import types
+
+# Create stub qrcode and PIL modules
+class DummyImage:
+    def __init__(self, size=(210, 210)):
+        self.size = size
+    def resize(self, size):
+        self.size = size
+        return self
+
+def _stub_modules():
+    qrcode_mod = types.ModuleType('qrcode')
+    class DummyQRCode:
+        def __init__(self, box_size=10, border=2):
+            pass
+        def add_data(self, data):
+            self.data = data
+        def make(self, fit=True):
+            pass
+        def make_image(self, fill_color='black', back_color='white'):
+            return DummyImage()
+    qrcode_mod.QRCode = DummyQRCode
+
+    pil_mod = types.ModuleType('PIL')
+    pil_image_mod = types.ModuleType('PIL.Image')
+    pil_image_mod.Image = DummyImage
+    pil_mod.Image = pil_image_mod
+
+    sys.modules['qrcode'] = qrcode_mod
+    sys.modules['PIL'] = pil_mod
+    sys.modules['PIL.Image'] = pil_image_mod
+
+_stub_modules()
+
+qrcode_utils = importlib.import_module('app.qrcode_utils')
+
+
+def test_generate_qr_code_size():
+    img = qrcode_utils.generate_qr_code('hello', size=100)
+    assert img.size == (100, 100)


### PR DESCRIPTION
## Summary
- document test execution in README
- expand code comments for clarity
- add pytest-based unit tests with stubbed dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845859f1d8c832b8824250f27df2ad4