### PR TITLE
Fix npm command usage for electron builds

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -28,10 +28,10 @@ jobs:
           node-version: "20"
 
       - name: Install Node deps
-        run: npm install --prefix electron
+        run: npm --prefix electron install
 
       - name: Build Windows app
-        run: npm run build --prefix electron
+        run: npm --prefix electron run build
 
       - name: Upload release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,10 +30,10 @@ jobs:
           node-version: '20'
 
       - name: Install Node deps
-        run: npm install --prefix electron
+        run: npm --prefix electron install
 
       - name: Build Electron app
-        run: npm run build --prefix electron
+        run: npm --prefix electron run build
 
       - name: Upload release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Summary
- adjust npm prefix usage in workflows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845d8207ec8832bb57ebed7e5554f9d