### PR TITLE
Fix npm install path in build workflows

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -28,10 +28,12 @@ jobs:
           node-version: "20"
 
       - name: Install Node deps
-        run: npm --prefix electron install
+        run: npm install
+        working-directory: ./electron
 
       - name: Build Windows app
-        run: npm --prefix electron run build
+        run: npm run build
+        working-directory: ./electron
 
       - name: Upload release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,10 +30,12 @@ jobs:
           node-version: '20'
 
       - name: Install Node deps
-        run: npm --prefix electron install
+        run: npm install
+        working-directory: ./electron
 
       - name: Build Electron app
-        run: npm --prefix electron run build
+        run: npm run build
+        working-directory: ./electron
 
       - name: Upload release
         uses: softprops/action-gh-release@v1

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Ziel des Projektes ist es, das Erstellen von Kalibrierungs- und Geraetebeschrift
    npm install
    cd ..
    ```
+   > **Hinweis:** Falls npm den Fehler `ENOENT` meldet, wird das Kommando meist
+   > im falschen Verzeichnis ausgefuehrt. Stelle sicher, dass du dich im
+   > `electron`-Ordner befindest oder dort eine `package.json` mit
+   > `npm init -y` erzeugst.
 
 ## ⚡ Lokaler Start (Streamlit)
 


### PR DESCRIPTION
## Summary
- fix npm install path in build workflows so `package.json` is found
- document npm ENOENT troubleshooting tip

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845d9d6aaec832bafb10c14e1992152