### PR TITLE
Add PyInstaller-based packaging

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -32,6 +32,11 @@ jobs:
       - name: Install Python dependencies
         run: pip install -r requirements.txt
 
+      - name: Build Python executable
+        run: |
+          pip install pyinstaller
+          pyinstaller --noconfirm --onefile --name labeltool --add-data "app;app" run.py
+
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 release/
 node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Ziel des Projektes ist es, das Erstellen von Kalibrierungs- und Geraetebeschrift
 
 ```bash
 streamlit run app/main.py
+# or
+python run.py
 ```
 
 Das Webinterface ist danach unter `http://localhost:8501` erreichbar.
@@ -59,6 +61,16 @@ npm start
 im Fenstermodus ausfuehren.
 
 ## ♻ Release Build
+
+The release packages depend on a bundled Python/Streamlit executable. Build it
+first using PyInstaller:
+
+```bash
+pip install pyinstaller
+pyinstaller --noconfirm --onefile --name labeltool --add-data "app;app" run.py
+```
+
+This creates `dist/labeltool.exe` which will be included in the Electron build.
 
 ```bash
 npm run build

--- a/electron/main.js
+++ b/electron/main.js
@@ -15,7 +15,12 @@ function createWindow() {
 }
 
 app.whenReady().then(() => {
-  const streamlit = spawn('streamlit', ['run', 'app/main.py']);
+  const exePath = path.join(__dirname, 'labeltool.exe');
+  const streamlit = spawn(exePath, [], {
+    detached: true,
+    stdio: 'ignore'
+  });
+  streamlit.unref();
   createWindow();
 
   app.on('activate', function () {

--- a/electron/package.json
+++ b/electron/package.json
@@ -15,9 +15,14 @@
       "output": "release"
     },
     "files": [
-      "../app/**/*",
-      "../assets/**/*",
+      "../dist/labeltool.exe",
       "**/*"
+    ],
+    "extraResources": [
+      {
+        "from": "../dist/labeltool.exe",
+        "to": "labeltool.exe"
+      }
     ],
     "win": {
       "target": [

--- a/run.py
+++ b/run.py
@@ -1,0 +1,11 @@
+import streamlit.web.bootstrap
+
+STREAMLIT_ARGS = {
+    "flag_options": ["--server.headless=true"],
+    "script_path": "app/main.py",
+}
+
+streamlit.web.bootstrap.run(
+    STREAMLIT_ARGS["script_path"],
+    flag_options=STREAMLIT_ARGS["flag_options"],
+)


### PR DESCRIPTION
## Summary
- enable PyInstaller packaging via workflow and docs
- provide `run.py` entry to launch Streamlit from Python API
- update Electron launcher to start the generated exe
- include exe in Electron build
- ignore dist build artifacts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845f68ac150832b849556e321937ad8