### PR TITLE
Add Windows signing helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 release/
 node_modules/
 dist/
+cert/*.pfx

--- a/README.md
+++ b/README.md
@@ -78,6 +78,26 @@ npm run build
 
 Der Befehl erzeugt im Ordner `release/` Installationspakete fuer Windows, Linux und macOS. Beim Pushen eines Tags in der Form `v1.0.0` wird dieser Schritt automatisch in GitHub Actions ausgefuehrt.
 
+### Signieren und ZIP-Installer (Windows)
+
+Um die erzeugte `labeltool.exe` lokal ohne Warnmeldungen ausfuehren zu koennen,
+kann sie mit einem selbstsignierten Zertifikat signiert werden. Die folgenden
+Befehle werden in einer PowerShell ausgefuehrt:
+
+```powershell
+# Selbstsigniertes Codesign-Zertifikat erstellen
+$cert = New-SelfSignedCertificate -Type CodeSigningCert -Subject "CN=Test Cert" -CertStoreLocation "cert:\CurrentUser\My"
+# Zertifikat als PFX exportieren (Thumbprint anpassen)
+Export-PfxCertificate -Cert "cert:\CurrentUser\My\$($cert.Thumbprint)" -FilePath cert\selfsign.pfx -Password (ConvertTo-SecureString -String "testpass" -Force -AsPlainText)
+
+# Signieren und ZIP erstellen
+./build-installer.ps1
+```
+
+Das Skript `build-installer.ps1` signiert die Datei `dist/labeltool.exe` mit dem
+vorher erzeugten Zertifikat und legt anschliessend `dist/labeltool.zip` als
+portables Paket an.
+
 ## Schritt-fuer-Schritt-Anleitung zum Testen
 
 1. **Server vorbereiten:** Stelle sicher, dass ein calServer mit gueltigen API-Zugangsdaten laeuft oder verwende Testendpunkte.

--- a/build-installer.ps1
+++ b/build-installer.ps1
@@ -1,0 +1,18 @@
+# Build and sign Windows executable and ZIP installer
+
+$cert = "cert\selfsign.pfx"
+$password = "testpass"
+$exe = "dist\labeltool.exe"
+$timestamp = "http://timestamp.digicert.com"
+
+# sign executable with self-signed certificate
+if (Test-Path $cert) {
+  & "C:\Program Files (x86)\Windows Kits\10\bin\x64\signtool.exe" sign `
+    /f $cert /p $password /tr $timestamp /td sha256 /fd sha256 `
+    $exe
+}
+
+# create portable ZIP package
+if (Test-Path $exe) {
+  Compress-Archive -Path $exe -DestinationPath dist\labeltool.zip -Force
+}


### PR DESCRIPTION
## Summary
- add helper script to sign labeltool.exe and zip it
- document signing workflow in README
- keep cert artifacts out of git

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845faa5700c832bb10648bca562f9bf