### PR TITLE
Use tag version for Electron build

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -46,6 +46,12 @@ jobs:
         run: npm install
         working-directory: electron
 
+      - name: Set version for Electron build
+        run: |
+          $version = "${{ github.event.inputs.version }}".TrimStart('v')
+          npm version $version --no-git-tag-version
+        working-directory: electron
+
       - name: Build Electron App (Windows)
         run: npm run build
         working-directory: electron


### PR DESCRIPTION
## Summary
- set dynamic version for Electron build in Windows workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68460cdd8920832b91afe3e132e930ff