### PR TITLE
Fix electron-is-dev packaging

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -23,9 +23,11 @@
       "artifactName": "${productName}-${version}-${os}-${arch}.${ext}"
     }
   },
+  "dependencies": {
+    "electron-is-dev": "^2.0.0"
+  },
   "devDependencies": {
     "electron": "^28.0.0",
-    "electron-builder": "^24.13.3",
-    "electron-is-dev": "^2.0.0"
+    "electron-builder": "^24.13.3"
   }
 }


### PR DESCRIPTION
## Summary
- ensure `electron-is-dev` is bundled by moving it to `dependencies`

## Testing
- `pytest -q`
- `npm install --package-lock-only` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684616ffbcc8832b96e5a9e25b984f23