### PR TITLE
Improve Electron startup wait logic

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -2,6 +2,7 @@ const { app, BrowserWindow } = require("electron");
 const { spawn } = require("child_process");
 const path = require("path");
 const isDev = require("electron-is-dev");
+const waitOn = require("wait-on");
 
 function createWindow() {
   const win = new BrowserWindow({
@@ -11,8 +12,6 @@ function createWindow() {
       contextIsolation: true
     }
   });
-
-  win.loadURL("http://localhost:8501");
 
   const exePath = isDev
     ? path.join(__dirname, "..", "dist", "labeltool.exe")
@@ -25,6 +24,14 @@ function createWindow() {
   });
 
   child.unref();
+
+  waitOn({ resources: ["http://localhost:8501"], timeout: 15000 }, (err) => {
+    if (err) {
+      console.error("Streamlit not available:", err);
+    } else {
+      win.loadURL("http://localhost:8501");
+    }
+  });
 }
 
 app.whenReady().then(createWindow);

--- a/electron/package.json
+++ b/electron/package.json
@@ -24,7 +24,8 @@
     }
   },
   "dependencies": {
-    "electron-is-dev": "^2.0.0"
+    "electron-is-dev": "^2.0.0",
+    "wait-on": "^7.1.1"
   },
   "devDependencies": {
     "electron": "^28.0.0",


### PR DESCRIPTION
## Summary
- wait for Streamlit server before loading UI
- declare `wait-on` dependency for Electron app

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68461d6f4c98832bb9473b9801502721