### PR TITLE
Add setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Ziel des Projektes ist es, das Erstellen von Kalibrierungs- und Geraetebeschrift
    > `electron`-Ordner befindest oder dort eine `package.json` mit
    > `npm init -y` erzeugst.
 
+4. Alternativ koennen alle Abhaengigkeiten in einem Schritt installiert
+   werden:
+   ```bash
+   ./setup.sh
+   ```
+
 ## ⚡ Lokaler Start (NiceGUI)
 
 ```bash

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Install Python and (optional) Node dependencies for calServer Labeltool
+set -e
+
+if [ ! -f requirements.txt ]; then
+    echo "Please run this script from the repository root" >&2
+    exit 1
+fi
+
+echo "Installing Python dependencies..."
+python3 -m pip install -r requirements.txt
+
+if [ -f electron/package.json ]; then
+    if command -v npm >/dev/null 2>&1; then
+        echo "Installing Node dependencies for Electron..."
+        (cd electron && npm install)
+    else
+        echo "npm not found: skipping Electron dependency installation" >&2
+    fi
+fi
+
+echo "Setup completed."


### PR DESCRIPTION
## Summary
- add `setup.sh` to install Python and Node dependencies
- document `setup.sh` usage in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68462c5f5cec832b9c169e3175af427e