### PR TITLE
Improve printer module imports

### DIFF
--- a/app/print_utils.py
+++ b/app/print_utils.py
@@ -5,21 +5,33 @@ from typing import List
 from PIL import Image
 
 
-if platform.system() == 'Windows':
-    import win32print
-elif platform.system() in ('Linux', 'Darwin'):
-    import cups
-else:
-    win32print = None
-    cups = None
+win32print = None
+cups = None
+
+if platform.system() == "Windows":
+    try:  # pragma: no cover - optional dependency may be missing
+        import win32print as _win32print
+        win32print = _win32print
+    except ImportError:  # pragma: no cover - handled below
+        win32print = None
+elif platform.system() in ("Linux", "Darwin"):
+    try:  # pragma: no cover - optional dependency may be missing
+        import cups as _cups
+        cups = _cups
+    except ImportError:  # pragma: no cover - handled below
+        cups = None
 
 
 def list_printers() -> List[str]:
     """Return a list of available printer names."""
 
-    if platform.system() == 'Windows' and win32print:
+    if platform.system() == "Windows":
+        if not win32print:
+            raise RuntimeError("win32print is required on Windows")
         return [p[2] for p in win32print.EnumPrinters(2)]
-    elif platform.system() in ('Linux', 'Darwin') and cups:
+    elif platform.system() in ("Linux", "Darwin"):
+        if not cups:
+            raise RuntimeError("cups is required on this platform")
         conn = cups.Connection()
         return list(conn.getPrinters().keys())
     return []
@@ -32,25 +44,29 @@ def print_label(image: Image.Image, printer_name: str) -> None:
     platforms a ``RuntimeError`` is raised.
     """
 
-    if platform.system() == 'Windows' and win32print:
+    if platform.system() == "Windows":
+        if not win32print:
+            raise RuntimeError("win32print is required on Windows")
         import tempfile
-        tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.bmp')
+        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".bmp")
         image.save(tmp.name)
         hPrinter = win32print.OpenPrinter(printer_name)
         try:
-            hJob = win32print.StartDocPrinter(hPrinter, 1, ('Label', None, 'RAW'))
+            win32print.StartDocPrinter(hPrinter, 1, ("Label", None, "RAW"))
             win32print.StartPagePrinter(hPrinter)
-            with open(tmp.name, 'rb') as f:
+            with open(tmp.name, "rb") as f:
                 win32print.WritePrinter(hPrinter, f.read())
             win32print.EndPagePrinter(hPrinter)
             win32print.EndDocPrinter(hPrinter)
         finally:
             win32print.ClosePrinter(hPrinter)
-    elif platform.system() in ('Linux', 'Darwin') and cups:
+    elif platform.system() in ("Linux", "Darwin"):
+        if not cups:
+            raise RuntimeError("cups is required on this platform")
         conn = cups.Connection()
         import tempfile
-        tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.png')
+        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".png")
         image.save(tmp.name)
-        conn.printFile(printer_name, tmp.name, 'Label', {})
+        conn.printFile(printer_name, tmp.name, "Label", {})
     else:
-        raise RuntimeError('Unsupported OS or printing not configured')
+        raise RuntimeError("Unsupported OS or printing not configured")

--- a/tests/test_list_printers.py
+++ b/tests/test_list_printers.py
@@ -1,24 +1,46 @@
 import importlib
 import sys
 import types
+import pytest
 
-# Prepare stub PIL modules since print_utils requires them
-pil_mod = types.ModuleType('PIL')
-pil_image_mod = types.ModuleType('PIL.Image')
+
 class DummyImage:
     pass
-pil_image_mod.Image = DummyImage
-pil_mod.Image = pil_image_mod
-sys.modules['PIL'] = pil_mod
-sys.modules['PIL.Image'] = pil_image_mod
-sys.modules['win32print'] = types.ModuleType('win32print')
-sys.modules['cups'] = types.ModuleType('cups')
 
-print_utils = importlib.import_module('app.print_utils')
+
+def _load_print_utils(with_win32=True, with_cups=True):
+    pil_mod = types.ModuleType("PIL")
+    pil_image_mod = types.ModuleType("PIL.Image")
+    pil_image_mod.Image = DummyImage
+    pil_mod.Image = pil_image_mod
+    sys.modules["PIL"] = pil_mod
+    sys.modules["PIL.Image"] = pil_image_mod
+
+    if with_win32:
+        sys.modules["win32print"] = types.ModuleType("win32print")
+    else:
+        sys.modules.pop("win32print", None)
+
+    if with_cups:
+        sys.modules["cups"] = types.ModuleType("cups")
+    else:
+        sys.modules.pop("cups", None)
+
+    if "app.print_utils" in sys.modules:
+        return importlib.reload(sys.modules["app.print_utils"])
+    return importlib.import_module("app.print_utils")
 
 
 def test_list_printers_unknown(monkeypatch):
-    monkeypatch.setattr(print_utils.platform, 'system', lambda: 'Other')
-    assert print_utils.list_printers() == []
+    pu = _load_print_utils()
+    monkeypatch.setattr(pu.platform, 'system', lambda: 'Other')
+    assert pu.list_printers() == []
+
+
+def test_list_printers_missing_dependency(monkeypatch):
+    pu = _load_print_utils(with_win32=False, with_cups=False)
+    monkeypatch.setattr(pu.platform, 'system', lambda: 'Linux')
+    with pytest.raises(RuntimeError):
+        pu.list_printers()
 
 

--- a/tests/test_print_utils.py
+++ b/tests/test_print_utils.py
@@ -3,27 +3,44 @@ import sys
 import types
 import pytest
 
-# Stub PIL module for import
 class DummyImage:
     def save(self, path):
         pass
 
-pil_mod = types.ModuleType('PIL')
-pil_image_mod = types.ModuleType('PIL.Image')
-pil_image_mod.Image = DummyImage
-pil_mod.Image = pil_image_mod
-sys.modules['PIL'] = pil_mod
-sys.modules['PIL.Image'] = pil_image_mod
 
-# Stub cups and win32print modules
-sys.modules['cups'] = types.ModuleType('cups')
-sys.modules['win32print'] = types.ModuleType('win32print')
+def _load_print_utils(with_win32=True, with_cups=True):
+    pil_mod = types.ModuleType("PIL")
+    pil_image_mod = types.ModuleType("PIL.Image")
+    pil_image_mod.Image = DummyImage
+    pil_mod.Image = pil_image_mod
+    sys.modules["PIL"] = pil_mod
+    sys.modules["PIL.Image"] = pil_image_mod
 
-print_utils = importlib.import_module('app.print_utils')
+    if with_win32:
+        sys.modules["win32print"] = types.ModuleType("win32print")
+    else:
+        sys.modules.pop("win32print", None)
+
+    if with_cups:
+        sys.modules["cups"] = types.ModuleType("cups")
+    else:
+        sys.modules.pop("cups", None)
+
+    if "app.print_utils" in sys.modules:
+        return importlib.reload(sys.modules["app.print_utils"])
+    return importlib.import_module("app.print_utils")
 
 
 def test_print_label_unsupported(monkeypatch):
-    monkeypatch.setattr(print_utils.platform, 'system', lambda: 'Other')
+    pu = _load_print_utils()
+    monkeypatch.setattr(pu.platform, 'system', lambda: 'Other')
     with pytest.raises(RuntimeError):
-        print_utils.print_label(DummyImage(), 'dummy')
+        pu.print_label(DummyImage(), 'dummy')
+
+
+def test_print_label_missing_dependency(monkeypatch):
+    pu = _load_print_utils(with_win32=False, with_cups=False)
+    monkeypatch.setattr(pu.platform, 'system', lambda: 'Windows')
+    with pytest.raises(RuntimeError):
+        pu.print_label(DummyImage(), 'dummy')
 


### PR DESCRIPTION
## Summary
- gracefully handle optional print modules
- reload print utilities in tests for independence
- test behaviour when printing dependencies are missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684710423f14832ba768212f72748ff2