### PR TITLE
Clean up temp files after printing

### DIFF
--- a/tests/test_print_utils.py
+++ b/tests/test_print_utils.py
@@ -27,3 +27,61 @@ def test_print_label_unsupported(monkeypatch):
     with pytest.raises(RuntimeError):
         print_utils.print_label(DummyImage(), 'dummy')
 
+
+class DummyTmp:
+    def __init__(self, name='tmp'):
+        self.name = name
+        self.closed = False
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        self.closed = True
+
+
+class DummyFile:
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        pass
+    def read(self):
+        return b''
+
+
+def test_print_label_windows_cleanup(monkeypatch):
+    tmp = DummyTmp('win_tmp')
+    monkeypatch.setattr(print_utils.platform, 'system', lambda: 'Windows')
+    monkeypatch.setattr(print_utils.tempfile, 'NamedTemporaryFile', lambda delete=False, suffix='': tmp)
+    monkeypatch.setattr(print_utils, 'win32print', types.SimpleNamespace(
+        OpenPrinter=lambda p: 'h',
+        StartDocPrinter=lambda h, lvl, info: None,
+        StartPagePrinter=lambda h: None,
+        WritePrinter=lambda h, data: None,
+        EndPagePrinter=lambda h: None,
+        EndDocPrinter=lambda h: None,
+        ClosePrinter=lambda h: None,
+    ), raising=False)
+    unlinked = []
+    monkeypatch.setattr(print_utils.os, 'unlink', lambda path: unlinked.append(path))
+    monkeypatch.setattr('builtins.open', lambda *args, **kwargs: DummyFile())
+
+    print_utils.print_label(DummyImage(), 'dummy')
+
+    assert tmp.closed
+    assert unlinked == [tmp.name]
+
+
+def test_print_label_cups_cleanup(monkeypatch):
+    tmp = DummyTmp('cups_tmp')
+    monkeypatch.setattr(print_utils.platform, 'system', lambda: 'Linux')
+    monkeypatch.setattr(print_utils.tempfile, 'NamedTemporaryFile', lambda delete=False, suffix='': tmp)
+    monkeypatch.setattr(print_utils, 'cups', types.SimpleNamespace(
+        Connection=lambda: types.SimpleNamespace(printFile=lambda *a, **kw: None)
+    ))
+    unlinked = []
+    monkeypatch.setattr(print_utils.os, 'unlink', lambda path: unlinked.append(path))
+
+    print_utils.print_label(DummyImage(), 'dummy')
+
+    assert tmp.closed
+    assert unlinked == [tmp.name]
+


### PR DESCRIPTION
## Summary
- close temporary files after saving
- remove them after printing on both Windows and CUPS
- add tests ensuring temp files are closed and deleted

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68471046e1f8832ba8652176ec8b3992