### PR TITLE
Fix print_utils reference in tests

### DIFF
--- a/tests/test_print_utils.py
+++ b/tests/test_print_utils.py
@@ -65,6 +65,7 @@ class DummyFile:
 
 
 def test_print_label_windows_cleanup(monkeypatch):
+    print_utils = _load_print_utils()
     tmp = DummyTmp('win_tmp')
     monkeypatch.setattr(print_utils.platform, 'system', lambda: 'Windows')
     monkeypatch.setattr(print_utils.tempfile, 'NamedTemporaryFile', lambda delete=False, suffix='': tmp)
@@ -88,6 +89,7 @@ def test_print_label_windows_cleanup(monkeypatch):
 
 
 def test_print_label_cups_cleanup(monkeypatch):
+    print_utils = _load_print_utils()
     tmp = DummyTmp('cups_tmp')
     monkeypatch.setattr(print_utils.platform, 'system', lambda: 'Linux')
     monkeypatch.setattr(print_utils.tempfile, 'NamedTemporaryFile', lambda delete=False, suffix='': tmp)


### PR DESCRIPTION
## Summary
- load `print_utils` module in cleanup tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847310e8d20832ba6026c4ecc40cfb4