### PR TITLE
Fix packaging output names

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -19,8 +19,7 @@
       }
     ],
     "win": {
-      "target": ["nsis", "portable"],
-      "artifactName": "${productName}-${version}-${os}-${arch}.${ext}"
+      "target": ["nsis", "portable"]
     }
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- reset artifact naming for electron builds to use default filenames

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847338f1bfc832bbb3cb6f3615928a8