### PR TITLE
Fix NiceGUI port for Electron integration

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -79,7 +79,7 @@ def main() -> None:
     ui.button("Fetch Data", on_click=fetch)
     ui.button("Print", on_click=do_print)
 
-    ui.run()
+    ui.run(port=8080, show=False)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual start


### PR DESCRIPTION
## Summary
- ensure NiceGUI always runs on port 8080 without opening a browser

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684739db47ec832bad1e75d3617de00b