### PR TITLE
Allow launcher to start without APP_CONFIG

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -7,7 +7,7 @@ Usage:
 Run this script directly to start the NiceGUI application.
 
 Environment:
-- Set APP_CONFIG to specify the application configuration file.
+- APP_CONFIG (optional): path to an application configuration file.
 
 Command-line arguments:
 --debug   Run in debug mode (more verbose logging)
@@ -29,8 +29,7 @@ def setup_logging(debug: bool):
 
 def check_environment():
     if not os.getenv("APP_CONFIG"):
-        logging.error("APP_CONFIG environment variable is not set.")
-        sys.exit(1)
+        logging.warning("APP_CONFIG environment variable is not set; using defaults.")
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Launch NiceGUI app.")


### PR DESCRIPTION
## Summary
- mark `APP_CONFIG` environment variable as optional
- soften `check_environment` so it only logs a warning
- keep the launcher running even if `APP_CONFIG` is missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68473fdb27f8832bad08084d2e1a4d69