### PR TITLE
Update PyInstaller commands

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build Python executable
         run: |
           pip install pyinstaller
-          pyinstaller --noconfirm --onefile --name labeltool --add-data "app;app" launcher.py
+          pyinstaller --noconfirm --onefile --noconsole --name labeltool --add-data "app;app" launcher.py
 
       - name: Set up Node.js
         uses: actions/setup-node@v3

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ headless mode. Build it first using PyInstaller:
 
 ```bash
 pip install pyinstaller
-pyinstaller --noconfirm --onefile --name labeltool --add-data "app;app" launcher.py
+pyinstaller --noconfirm --onefile --noconsole --name labeltool --add-data "app;app" launcher.py
 ```
 
 This creates `dist/labeltool.exe` which will be included in the Electron build.

--- a/build-installer.ps1
+++ b/build-installer.ps1
@@ -9,7 +9,7 @@ $timestamp = "http://timestamp.digicert.com"
 if (-not (Get-Command pyinstaller -ErrorAction SilentlyContinue)) {
   python -m pip install pyinstaller | Out-Null
 }
-pyinstaller --noconfirm --onefile --name labeltool --add-data "app;app" launcher.py
+pyinstaller --noconfirm --onefile --noconsole --name labeltool --add-data "app;app" launcher.py
 
 # sign executable with self-signed certificate
 if (Test-Path $cert -and Test-Path $exe) {


### PR DESCRIPTION
## Summary
- add `--noconsole` to PyInstaller invocation in the Windows workflow
- update PowerShell build script for no-console build
- document new option in the release steps

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684746c28abc832bbe6dc55b7ad7a2dc