### PR TITLE
Add Windows installer configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Ziel des Projektes ist es, das Erstellen von Kalibrierungs- und Geraetebeschrift
    ```bash
    ./setup.sh
    ```
+5. Windows-Nutzer koennen stattdessen die WinGet-Konfiguration nutzen,
+   um Python, Node.js, Visual Studio Code und saemtliche
+   Projektabhaengigkeiten automatisch einzurichten:
+   ```powershell
+   winget configure --file install-windows.yaml
+   ```
 
 ## ⚡ Lokaler Start (NiceGUI)
 

--- a/install-dependencies.ps1
+++ b/install-dependencies.ps1
@@ -1,0 +1,11 @@
+param()
+
+Write-Host "Installing Python packages..."
+pip install -r requirements.txt
+
+if (Test-Path "electron\package.json") {
+    Write-Host "Installing Node packages..."
+    pushd electron
+    npm install
+    popd
+}

--- a/install-windows.yaml
+++ b/install-windows.yaml
@@ -1,0 +1,57 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+# WinGet configuration for installing calServer Labeltool dependencies on Windows
+#
+# This will:
+#   * Install Python 3.13
+#   * Install Visual Studio Code
+#   * Install the VS Code Python extension
+#   * Install Node.js LTS
+#   * Install Python and Node dependencies of the application
+
+properties:
+  resources:
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: Python
+      directives:
+        description: Install Python 3.13
+      settings:
+        id: 9PNRBTZXMB4Z
+        source: msstore
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: Visual Studio Code
+      directives:
+        description: Install Visual Studio Code
+      settings:
+        id: Microsoft.VisualStudioCode
+        source: winget
+    - resource: Microsoft.VSCode.Dsc/VSCodeExtension
+      id: ms-python.python
+      dependsOn:
+        - Visual Studio Code
+      directives:
+        description: Install Python Visual Studio Code extension
+        allowPrerelease: true
+      settings:
+        name: ms-python.python
+        exist: true
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: Node.js
+      directives:
+        description: Install Node.js LTS
+      settings:
+        id: OpenJS.NodeJS.LTS
+        source: winget
+    - resource: Microsoft.PowerShell.Dsc/Script
+      id: Install calServer dependencies
+      dependsOn:
+        - Python
+        - Node.js
+      directives:
+        description: Install Python and Node packages for calServer Labeltool
+      settings:
+        getScript: ''
+        setScript: |
+          $scriptPath = Join-Path $PWD 'install-dependencies.ps1'
+          & $scriptPath
+        testScript: 'exit 1'
+  configurationVersion: 0.2.0


### PR DESCRIPTION
## Summary
- add install-windows.yaml for winget to install prerequisites and app deps
- add install-dependencies.ps1 script invoked from winget config
- document usage of the new configuration in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68474b1acd00832b98637f9218fbfa37