### PR TITLE
Clarify Node requirement and improve script check

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Ziel des Projektes ist es, das Erstellen von Kalibrierungs- und Geraetebeschrift
    npm install
    cd ..
    ```
+   Node.js muss installiert sein, damit `npm` verfuegbar ist. Fehlt `npm`,
+   laesst sich Node.js ueber <https://nodejs.org/> oder per
+   `winget install OpenJS.NodeJS.LTS` nachinstallieren.
    > **Hinweis:** Falls npm den Fehler `ENOENT` meldet, wird das Kommando meist
    > im falschen Verzeichnis ausgefuehrt. Stelle sicher, dass du dich im
    > `electron`-Ordner befindest oder dort eine `package.json` mit

--- a/install-dependencies.ps1
+++ b/install-dependencies.ps1
@@ -4,8 +4,14 @@ Write-Host "Installing Python packages..."
 pip install -r requirements.txt
 
 if (Test-Path "electron\package.json") {
-    Write-Host "Installing Node packages..."
-    pushd electron
-    npm install
-    popd
+    if (Get-Command npm -ErrorAction SilentlyContinue) {
+        Write-Host "Installing Node packages..."
+        pushd electron
+        npm install
+        popd
+    }
+    else {
+        Write-Warning "npm not found. Skipping Node package installation."
+        Write-Host "Install Node.js (https://nodejs.org/) or run `winget install OpenJS.NodeJS.LTS` and re-run this script."
+    }
 }


### PR DESCRIPTION
## Summary
- document that Node.js must be installed when running `npm install`
- check for `npm` in `install-dependencies.ps1` and provide hint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847512a9994832ba1964965fff5d69b