### PR TITLE
Add log window and login data cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Ziel des Projektes ist es, das Erstellen von Kalibrierungs- und Geraetebeschrift
 - Generierung von QR-Codes
 - Ausgabe auf beliebigen lokalen Druckern
 - Optionale Nutzung als Electron-Desktop-Anwendung
+- Ausführliches Logfenster zur Fehlerdiagnose
+- Temporäres Speichern der eingegebenen Login-Daten
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- provide a log window in the NiceGUI interface
- remember login values during runtime
- document new features in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68475bc37d84832bbd73d4bbc4d28993