### PR TITLE
Display device data in NiceGUI table

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -32,6 +32,18 @@ def main() -> None:
     cal_data = {}
     current_image: Image.Image | None = None
 
+    # table configuration for displaying device data
+    table_columns = [
+        {"name": "I4201", "label": "Gerätename", "field": "I4201"},
+        {"name": "I4202", "label": "Hersteller", "field": "I4202"},
+        {"name": "I4203", "label": "Typ", "field": "I4203"},
+        {"name": "I4204", "label": "Beschreibung", "field": "I4204"},
+        {"name": "I4206", "label": "Seriennummer", "field": "I4206"},
+        {"name": "C2301", "label": "Kalibrierdatum", "field": "C2301"},
+        {"name": "C2303", "label": "Ablaufdatum", "field": "C2303"},
+    ]
+    table_rows: list[dict] = []
+
     # main card containing all form elements
     card = ui.card().style(
         "max-width: 420px; margin: 80px auto; box-shadow: 0 2px 8px rgba(0,0,0,0.13);"
@@ -119,20 +131,58 @@ def main() -> None:
                 "api_key": api_key.value,
                 "filter_json": filter_json.value,
             })
+            user_filter = json.loads(filter_json.value or "{}")
+            user_filter["C2339"] = "1"
             data = fetch_calibration_data(
                 base_url.value,
                 username.value,
                 password.value,
                 api_key.value,
-                json.loads(filter_json.value or "{}"),
+                user_filter,
             )
-            cal_data = data
-            ui.notify("Data loaded", type="positive")
+
+            # extract calibration list from API response
+            if isinstance(data, dict):
+                if isinstance(data.get("data"), dict) and isinstance(
+                    data["data"].get("calibration"), list
+                ):
+                    cal_list = data["data"]["calibration"]
+                else:
+                    cal_list = [data]
+            elif isinstance(data, list):
+                cal_list = data
+            else:
+                cal_list = []
+
+            # convert API structure to table rows
+            rows = []
+            for entry in cal_list:
+                inv = entry.get("inventory") or {}
+                rows.append(
+                    {
+                        "I4201": inv.get("I4201"),
+                        "I4202": inv.get("I4202"),
+                        "I4203": inv.get("I4203"),
+                        "I4204": inv.get("I4204"),
+                        "I4206": inv.get("I4206"),
+                        "C2301": entry.get("C2301"),
+                        "C2303": entry.get("C2303"),
+                    }
+                )
+
+            table_rows.clear()
+            table_rows.extend(rows)
+            cal_data = cal_list[0] if cal_list else {}
+            device_table.update()
+            ui.notify("Daten geladen", type="positive")
             log_window.push("Data loaded successfully")
             update_label()
         except Exception as e:  # pragma: no cover - UI only
+            ui.notify(f"Fehler beim Laden der Gerätedaten: {e}", type="negative")
+            table_rows.clear()
+            cal_data = {}
+            device_table.update()
             log_window.push(f"Error: {e}")
-            ui.notify(str(e), type="negative")
 
     def update_label() -> None:
         nonlocal current_image
@@ -168,6 +218,16 @@ def main() -> None:
             ui.button("Fetch Data", on_click=fetch).props("color=primary")
             ui.button("Print", on_click=do_print).props("color=secondary")
         login_status = ui.label("").classes("text-positive")
+
+    # table showing relevant device information
+    device_table = ui.table(
+        columns=table_columns,
+        rows=table_rows,
+        row_key="I4206",
+        pagination=True,
+        rows_per_page=10,
+        search=True,
+    ).classes("q-mt-lg")
 
     ui.run(port=8080, show=False)
 


### PR DESCRIPTION
## Summary
- add a dynamic NiceGUI table listing required API fields
- update `fetch()` to fill the table and handle different response formats
- ensure API filter `C2339=1` and map `inventory` fields for the table

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847b8fa9c9c832bafe6ce711190fa47