### PR TITLE
Fix NiceGUI table parameter compatibility

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -226,8 +226,9 @@ def main() -> None:
         rows=table_rows,
         row_key="I4206",
         pagination=True,
-        search=True,
     )
+    if "search" in inspect.signature(ui.table).parameters:
+        table_kwargs["search"] = True
     if "rows_per_page" in inspect.signature(ui.table).parameters:
         table_kwargs["rows_per_page"] = 10
     device_table = ui.table(**table_kwargs).classes("q-mt-lg")


### PR DESCRIPTION
## Summary
- check for `search` parameter in NiceGUI table
- avoid `rows_per_page` and `search` on older NiceGUI versions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847bfb5c124832bb0e26986bb33374c