### PR TITLE
Add docker-compose setup with Let's Encrypt and fix table fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Replace with your domain and contact email
+DOMAIN=example.com
+LETSENCRYPT_EMAIL=admin@example.com

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ release/
 node_modules/
 dist/
 cert/*.pfx
+.env
+certs/
+vhost.d/
+html/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "run.py"]

--- a/README.md
+++ b/README.md
@@ -78,6 +78,29 @@ npm start
 
 im Fenstermodus ausfuehren.
 
+## 🐳 Docker Compose
+
+Für den produktiven Einsatz liegt ein einfaches Docker‑Compose Setup bei.
+Damit lässt sich die Anwendung zusammen mit einem Nginx‑Reverse‑Proxy und
+automatisch erneuerten Let's‑Encrypt Zertifikaten starten.
+
+1. `.env.example` kopieren und die Werte für `DOMAIN` und
+   `LETSENCRYPT_EMAIL` anpassen:
+
+   ```bash
+   cp .env.example .env
+   # DOMAIN=my.example.com
+   # LETSENCRYPT_EMAIL=admin@my.example.com
+   ```
+
+2. Danach das Setup starten:
+
+   ```bash
+   docker-compose up -d
+   ```
+
+   Die Anwendung ist anschließend unter `https://<DOMAIN>` erreichbar.
+
 ## ♻ Release Build
 
 Die Release-Pakete basieren auf einer gebuendelten Python/NiceGUI-Exe.

--- a/app/main.py
+++ b/app/main.py
@@ -231,7 +231,12 @@ def main() -> None:
         table_kwargs["search"] = True
     if "rows_per_page" in inspect.signature(ui.table).parameters:
         table_kwargs["rows_per_page"] = 10
-    device_table = ui.table(**table_kwargs).classes("q-mt-lg")
+    try:
+        device_table = ui.table(**table_kwargs).classes("q-mt-lg")
+    except TypeError:  # pragma: no cover - compatibility fallback
+        table_kwargs.pop("search", None)
+        table_kwargs.pop("rows_per_page", None)
+        device_table = ui.table(**table_kwargs).classes("q-mt-lg")
 
     ui.run(port=8080, show=False)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3'
+
+services:
+  app:
+    build: .
+    expose:
+      - "8080"
+    environment:
+      - VIRTUAL_HOST=${DOMAIN}
+      - LETSENCRYPT_HOST=${DOMAIN}
+      - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL}
+    restart: always
+
+  nginx-proxy:
+    image: jwilder/nginx-proxy:latest
+    container_name: nginx-proxy
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ./certs:/etc/nginx/certs
+      - ./vhost.d:/etc/nginx/vhost.d
+      - ./html:/usr/share/nginx/html
+    restart: always
+
+  letsencrypt:
+    image: jrcs/letsencrypt-nginx-proxy-companion:latest
+    environment:
+      - NGINX_PROXY_CONTAINER=nginx-proxy
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./certs:/etc/nginx/certs:rw
+      - ./vhost.d:/etc/nginx/vhost.d
+      - ./html:/usr/share/nginx/html
+    restart: always


### PR DESCRIPTION
## Summary
- add Dockerfile for the application
- provide docker-compose with nginx and automatic Let's Encrypt certificates
- document docker usage
- ignore docker runtime files
- handle NiceGUI table compatibility gracefully

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847c07f8f64832b90df93e74a578e38