### PR TITLE
Prefill login in dev mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 # Replace with your domain and contact email
-DOMAIN=example.com
+DOMAIN=demo.net-cal.com
 LETSENCRYPT_EMAIL=admin@example.com
+# Set to "development" to prefill login credentials
+# during local development
+APP_ENV=development

--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ python run.py
 
 Das Webinterface ist danach unter `http://localhost:8080` erreichbar.
 
+Wenn die Umgebungsvariable `APP_ENV` auf `development` gesetzt ist,
+werden die Login-Felder mit Demo-Zugangsdaten vorbefüllt. Ein Beispiel
+hierzu findet sich in `.env.example`, welches zudem den Eintrag
+`DOMAIN=demo.net-cal.com` für die Demo-API enthält.
+
 ## ⚡ Start als Desktop-App
 
 Im `electron`-Verzeichnis befinden sich die Dateien fuer die Electron-Anwendung. Nach der Installation der Node-Abhaengigkeiten laesst sich die App mit

--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import io
 import json
+import os
 from typing import Any, Dict, List
 
 from PIL import Image
@@ -198,10 +199,27 @@ def main() -> None:
     login_card = ui.card().style("max-width:420px;margin:80px auto;")
     with login_card:
         ui.label("calServer Labeltool").classes("text-h5 text-center q-mb-md")
-        base_url = ui.input("API URL", value="https://calserver.example.com").props("outlined")
-        username = ui.input("Benutzername").props("outlined")
+
+        # Prefill login fields in development mode. The DOMAIN environment
+        # variable determines the default URL. If APP_ENV is set to
+        # ``development`` additional credentials are populated as well.
+        is_dev = os.getenv("APP_ENV") == "development"
+        if is_dev:
+            domain = os.getenv("DOMAIN", "demo.net-cal.com")
+        else:
+            domain = os.getenv("DOMAIN", "calserver.example.com")
+        default_url = domain if domain.startswith("http") else f"https://{domain}"
+        base_url = ui.input("API URL", value=default_url).props("outlined")
+        username = ui.input(
+            "Benutzername",
+            value="api-demo@calhelp.de" if is_dev else "",
+        ).props("outlined")
         password = ui.input("Passwort", password=True).props("outlined")
-        api_key = ui.input("API Key", password=True).props("outlined")
+        api_key = ui.input(
+            "API Key",
+            password=True,
+            value="53f1871505fa8190659aaae17845bd19" if is_dev else "",
+        ).props("outlined")
         ui.button("Login", on_click=handle_login).props("color=primary")
 
     ui.run(port=8080, show=False)


### PR DESCRIPTION
## Summary
- prefill login fields from ENV in development mode
- add example environment file and docs for demo credentials

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847c6cfbbf8832bab1f1e8051263443