### PR TITLE
Fix disabled button for NiceGUI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -194,7 +194,8 @@ def main() -> None:
                     with label_card:
                         ui.label("Label-Vorschau").classes("text-h6")
                         label_img = ui.image("").classes("q-mb-md").style("max-width:260px;")
-                        print_button = ui.button("Drucken", on_click=do_print, disabled=True).props("color=primary")
+                        print_button = ui.button("Drucken", on_click=do_print).props("color=primary")
+                        print_button.disable()
             with ui.footer().classes("bg-grey-2 shadow-2"):
                 expansion = ui.expansion("Status anzeigen", value=False)
                 with expansion:


### PR DESCRIPTION
## Summary
- fix initialization error when creating the print button by removing the unsupported `disabled` parameter
- disable the print button after creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847c8b5e580832b916e895627ca1986