### PR TITLE
Add dotenv support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,5 @@ LETSENCRYPT_EMAIL=admin@example.com
 # Set to "development" to prefill login credentials
 # during local development
 APP_ENV=development
+# Path to optional application configuration
+# APP_CONFIG=/path/to/config.json

--- a/README.md
+++ b/README.md
@@ -71,7 +71,10 @@ Das Webinterface ist danach unter `http://localhost:8080` erreichbar.
 Wenn die Umgebungsvariable `APP_ENV` auf `development` gesetzt ist,
 werden die Login-Felder mit Demo-Zugangsdaten vorbefüllt. Ein Beispiel
 hierzu findet sich in `.env.example`, welches zudem den Eintrag
-`DOMAIN=demo.net-cal.com` für die Demo-API enthält.
+`DOMAIN=demo.net-cal.com` für die Demo-API enthält. Liegt eine `.env`
+Datei im Projektverzeichnis, wird sie beim Start über `launcher.py`
+automatisch mit **python-dotenv** eingelesen. Darin kann z.B. ein Pfad
+für `APP_CONFIG` gesetzt werden.
 
 ## ⚡ Start als Desktop-App
 

--- a/launcher.py
+++ b/launcher.py
@@ -17,6 +17,8 @@ import logging
 import argparse
 import os
 import sys
+
+from dotenv import load_dotenv
 from app.main import main
 
 def setup_logging(debug: bool):
@@ -28,8 +30,11 @@ def setup_logging(debug: bool):
     )
 
 def check_environment():
+    load_dotenv()
     if not os.getenv("APP_CONFIG"):
-        logging.warning("APP_CONFIG environment variable is not set; using defaults.")
+        logging.warning(
+            "APP_CONFIG environment variable is not set; using defaults."
+        )
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Launch NiceGUI app.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ qrcode
 pywin32; sys_platform == "win32"
 pycups; sys_platform != "win32"
 pytest
+python-dotenv


### PR DESCRIPTION
## Summary
- load variables from `.env` using python‑dotenv
- show example of `APP_CONFIG` in `.env.example`
- mention automatic loading in the README
- add python‑dotenv to requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847c886e6e8832bbc06209f59098337