### PR TITLE
Fix table pagination handling

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -30,6 +30,34 @@ def _pil_to_data_url(image: Image.Image) -> str:
     return f"data:image/png;base64,{data}"
 
 
+def _build_table_kwargs(table_func, rows: List[Dict[str, Any]], on_select) -> Dict[str, Any]:
+    """Return kwargs for ``ui.table`` with optional parameters."""
+
+    kwargs = dict(
+        columns=[
+            {"name": "I4201", "label": "Gerätename", "field": "I4201"},
+            {"name": "I4202", "label": "Hersteller", "field": "I4202"},
+            {"name": "I4203", "label": "Typ", "field": "I4203"},
+            {"name": "I4204", "label": "Beschreibung", "field": "I4204"},
+            {"name": "I4206", "label": "Seriennummer", "field": "I4206"},
+            {"name": "C2301", "label": "Kalibrierdatum", "field": "C2301"},
+            {"name": "C2303", "label": "Ablaufdatum", "field": "C2303"},
+        ],
+        rows=rows,
+        row_key="I4201",
+        on_select=on_select,
+    )
+
+    params = inspect.signature(table_func).parameters
+    if "pagination" in params:
+        kwargs["pagination"] = True
+    if "search" in params:
+        kwargs["search"] = True
+    if "rows_per_page" in params:
+        kwargs["rows_per_page"] = 10
+    return kwargs
+
+
 def main() -> None:
     """Run the NiceGUI label tool."""
 
@@ -170,25 +198,7 @@ def main() -> None:
             ui.button("Logout", on_click=logout).classes("absolute-top-right q-mt-sm q-mr-sm").props("icon=logout flat color=negative")
             with ui.row().classes("justify-center q-gutter-xl flex-wrap"):
                 with ui.column().style("flex:3;min-width:600px;max-width:900px"):
-                    table_kwargs = dict(
-                        columns=[
-                            {"name": "I4201", "label": "Gerätename", "field": "I4201"},
-                            {"name": "I4202", "label": "Hersteller", "field": "I4202"},
-                            {"name": "I4203", "label": "Typ", "field": "I4203"},
-                            {"name": "I4204", "label": "Beschreibung", "field": "I4204"},
-                            {"name": "I4206", "label": "Seriennummer", "field": "I4206"},
-                            {"name": "C2301", "label": "Kalibrierdatum", "field": "C2301"},
-                            {"name": "C2303", "label": "Ablaufdatum", "field": "C2303"},
-                        ],
-                        rows=table_rows,
-                        row_key="I4201",
-                        pagination=True,
-                        on_select=on_select,
-                    )
-                    if "search" in inspect.signature(ui.table).parameters:
-                        table_kwargs["search"] = True
-                    if "rows_per_page" in inspect.signature(ui.table).parameters:
-                        table_kwargs["rows_per_page"] = 10
+                    table_kwargs = _build_table_kwargs(ui.table, table_rows, on_select)
                     device_table = ui.table(**table_kwargs).classes("q-mt-md")
                     ui.button("Daten laden", on_click=fetch_data).props("color=primary").classes("q-mt-md")
                 with ui.column().style("flex:2;min-width:320px"):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,37 @@
+import importlib
+import sys
+import types
+
+# Provide stub modules so ``app.main`` can be imported without optional deps
+pil_mod = types.ModuleType("PIL")
+pil_image_mod = types.ModuleType("PIL.Image")
+class DummyImage:
+    pass
+
+pil_image_mod.Image = DummyImage
+pil_mod.Image = pil_image_mod
+sys.modules["PIL"] = pil_mod
+sys.modules["PIL.Image"] = pil_image_mod
+
+ng_mod = types.ModuleType("nicegui")
+ng_mod.ui = types.SimpleNamespace()
+sys.modules["nicegui"] = ng_mod
+sys.modules["nicegui.ui"] = ng_mod.ui
+
+from app import main
+
+
+def dummy_table_a(columns=None, rows=None, row_key=None, on_select=None, pagination=True):
+    pass
+
+
+def dummy_table_b(columns=None, rows=None, row_key=None, on_select=None):
+    pass
+
+
+def test_build_table_kwargs_optional_pagination():
+    kwargs_a = main._build_table_kwargs(dummy_table_a, [], None)
+    assert 'pagination' in kwargs_a
+
+    kwargs_b = main._build_table_kwargs(dummy_table_b, [], None)
+    assert 'pagination' not in kwargs_b


### PR DESCRIPTION
## Summary
- ensure optional table arguments are detected with `_build_table_kwargs`
- use helper in `show_main_ui` to avoid unexpected argument errors
- add tests for table kwargs logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847cc0b35a0832bbaf90bada6aed39b