### PR TITLE
Fix status log readability

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -249,9 +249,12 @@ def main() -> None:
     footer = ui.footer().classes("bg-grey-2 shadow-2")
     footer.visible = False
     with footer:
-        expansion = ui.expansion("Status anzeigen", value=False)
+        expansion = ui.expansion("Status anzeigen", value=False).classes("w-full")
         with expansion:
-            status_log = ui.log(max_lines=100)
+            status_log = (
+                ui.log(max_lines=100)
+                .classes("w-full bg-white text-black")
+            )
 
     ui.run(port=8080, show=False)
 


### PR DESCRIPTION
## Summary
- use a white background and black text for `status_log`
- make `status_log` fill the available width

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847ceed9f6c832b985daba37c6470a3