### PR TITLE
Install build deps for pycups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM python:3.11-slim
 WORKDIR /app
 COPY requirements.txt ./
+# Install required build tools and CUPS headers for pycups
+RUN apt-get update \
+    && apt-get install -y gcc python3-dev libcups2-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 CMD ["python", "run.py"]


### PR DESCRIPTION
## Summary
- install build tools and libcups headers for pycups in Docker image

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847ee8157c8832b9deac3d079f7c594