### PR TITLE
Fix NiceGUI startup for multiprocessing

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -273,5 +273,5 @@ def main() -> None:
     ui.run(port=8080, show=False)
 
 
-if __name__ == "__main__":  # pragma: no cover - manual start
+if __name__ in {"__main__", "__mp_main__"}:  # pragma: no cover - manual start
     main()

--- a/run.py
+++ b/run.py
@@ -3,5 +3,5 @@
 from app.main import main
 
 
-if __name__ == "__main__":  # pragma: no cover - manual start
+if __name__ in {"__main__", "__mp_main__"}:  # pragma: no cover - manual start
     main()


### PR DESCRIPTION
## Summary
- allow `run.py` and `app/main.py` to run when executed via multiprocessing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847f2fd45c4832ba0407bcf1665b5c3