### PR TITLE
Fix Docker env handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
-CMD ["python", "run.py"]
+CMD ["python", "launcher.py"]

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ automatisch erneuerten Let's‑Encrypt Zertifikaten starten.
    cp .env.example .env
    # DOMAIN=my.example.com
    # LETSENCRYPT_EMAIL=admin@my.example.com
+   # optional: APP_ENV=development
+   # optional: APP_CONFIG=/path/to/config.json
    ```
 
 2. Danach das Setup starten:
@@ -108,6 +110,8 @@ automatisch erneuerten Let's‑Encrypt Zertifikaten starten.
    ```
 
    Die Anwendung ist anschließend unter `https://<DOMAIN>` erreichbar.
+   Alle Variablen aus der `.env` Datei werden beim Start in den Container
+   übernommen und stehen der Anwendung zur Verfügung.
 
 ## ♻ Release Build
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,9 @@ services:
       - VIRTUAL_HOST=${DOMAIN}
       - LETSENCRYPT_HOST=${DOMAIN}
       - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL}
+      - DOMAIN=${DOMAIN}
+      - APP_ENV=${APP_ENV}
+      - APP_CONFIG=${APP_CONFIG}
     restart: always
 
   nginx-proxy:


### PR DESCRIPTION
## Summary
- run launcher with Docker so `.env` variables load automatically
- pass DOMAIN, APP_ENV and APP_CONFIG into the Docker container
- clarify Docker instructions in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848073bda7c832badf66b824921288a