### PR TITLE
Set default page size and add label preview test

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -53,7 +53,9 @@ def _build_table_kwargs(table_func, rows: List[Dict[str, Any]], on_select) -> Di
         kwargs["pagination"] = True
     if "search" in params:
         kwargs["search"] = True
-    if "rows_per_page" in params:
+    if "rows_per_page" in params or any(
+        p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
+    ):
         kwargs["rows_per_page"] = 10
     if "selection" in params:
         kwargs["selection"] = "single"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -44,3 +44,12 @@ def test_build_table_kwargs_optional_pagination():
 def test_build_table_kwargs_selection():
     kwargs_c = main._build_table_kwargs(dummy_table_c, [], None)
     assert kwargs_c.get('selection') == 'single'
+
+
+def test_pil_to_data_url_prefix():
+    class DummyImg:
+        def save(self, buffer, format=None):
+            buffer.write(b'test')
+
+    result = main._pil_to_data_url(DummyImg())
+    assert result.startswith('data:image/png;base64,')


### PR DESCRIPTION
## Summary
- ensure tables show 10 rows per page regardless of NiceGUI signature quirks
- add regression test checking that preview image URLs are properly formatted

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684812d5b944832b94a8da5dd32ecf11