### PR TITLE
Add MTAG field support and update device labels

### DIFF
--- a/app/label_templates.py
+++ b/app/label_templates.py
@@ -6,18 +6,27 @@ from .qrcode_utils import generate_qr_code
 FONT = ImageFont.load_default()
 
 
-def device_label(name: str, device_id: str) -> Image.Image:
+def device_label(name: str, expiry: str, mtag: str) -> Image.Image:
     """Create a label image for a device.
 
-    The label contains the device name, its identifier and a QR code
-    encoding the identifier.
+    Parameters
+    ----------
+    name:
+        Device name to show on the label.
+    expiry:
+        Expiry date of the calibration/approval.
+    mtag:
+        Value to encode in the QR code.
+
+    The label contains the device name, the expiry date and a QR code
+    encoding the provided ``mtag`` value.
     """
 
     img = Image.new("RGB", (400, 200), color="white")
     draw = ImageDraw.Draw(img)
-    draw.text((10, 10), name, font=FONT, fill="black")
-    draw.text((10, 50), f"ID: {device_id}", font=FONT, fill="black")
-    qr = generate_qr_code(device_id, size=100)
+    draw.text((10, 10), f"Gerät: {name}", font=FONT, fill="black")
+    draw.text((10, 50), f"Ablauf: {expiry}", font=FONT, fill="black")
+    qr = generate_qr_code(mtag, size=100)
     img.paste(qr, (280, 10))
     return img
 

--- a/app/main.py
+++ b/app/main.py
@@ -167,6 +167,7 @@ def main() -> None:
                         "I4206": inv.get("I4206") or "-",
                         "C2301": entry.get("C2301") or "-",
                         "C2303": entry.get("C2303") or "-",
+                        "MTAG": entry.get("MTAG") or inv.get("MTAG") or "-",
                     }
                 )
             table_rows.clear()
@@ -198,7 +199,12 @@ def main() -> None:
                 print_button.disable()
             return
 
-        img = device_label(row.get("I4201", ""), row.get("I4206", ""))
+        name = row.get("I4201", "")
+        expiry = row.get("C2303", "")
+        mtag = row.get("MTAG", "")
+        if not mtag or mtag == "-":
+            push_status("MTAG fehlt für ausgewähltes Gerät")
+        img = device_label(name, expiry, mtag)
         current_image = img
         if label_img:
             label_img.set_source(_pil_to_data_url(img))

--- a/tests/test_label_templates.py
+++ b/tests/test_label_templates.py
@@ -65,17 +65,17 @@ label_templates = importlib.import_module("app.label_templates")
 
 
 def test_device_label_contents():
-    img = label_templates.device_label("Device", "123")
+    img = label_templates.device_label("Device", "2025-01-01", "MT123")
 
     assert img.pasted, "QR code not pasted"
     qr, pos = img.pasted[0]
     assert isinstance(qr, DummyQR)
-    assert qr.data == "123"
+    assert qr.data == "MT123"
     assert pos == (280, 10)
 
     texts = [t for _, t in img.drawn_text]
-    assert "Device" in texts[0]
-    assert "ID: 123" in texts[1]
+    assert "Gerät: Device" in texts[0]
+    assert "Ablauf: 2025-01-01" in texts[1]
 
 
 def test_calibration_label_contents():


### PR DESCRIPTION
## Summary
- include `MTAG` on data fetch
- adapt device label to use device name, expiry and MTAG
- handle missing MTAG in UI
- update tests to reflect new label format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684823ae4bd8832ba82be3103567ea60