### PR TITLE
Use print flag filter

### DIFF
--- a/app/calserver_api.py
+++ b/app/calserver_api.py
@@ -1,5 +1,6 @@
 """Small wrapper around the calServer REST API."""
 
+import json
 import requests
 from typing import Any, Dict
 
@@ -9,7 +10,7 @@ def fetch_calibration_data(
     username: str,
     password: str,
     api_key: str,
-    filter_json: Dict[str, Any],
+    filter_json: Dict[str, Any] | list,
 ) -> Dict[str, Any]:
     """Fetch calibration information from the API.
 
@@ -35,11 +36,12 @@ def fetch_calibration_data(
         Parsed JSON content of the successful API response.
     """
     params = {
-        'HTTP_X_REST_USERNAME': username,
-        'HTTP_X_REST_PASSWORD': password,
-        'HTTP_X_REST_API_KEY': api_key,
+        "HTTP_X_REST_USERNAME": username,
+        "HTTP_X_REST_PASSWORD": password,
+        "HTTP_X_REST_API_KEY": api_key,
+        "filter": json.dumps(filter_json),
     }
     url = f"{base_url.rstrip('/')}/api/calibration"
-    response = requests.get(url, params=params, json=filter_json, timeout=10)
+    response = requests.get(url, params=params, timeout=10)
     response.raise_for_status()
     return response.json()

--- a/app/main.py
+++ b/app/main.py
@@ -9,6 +9,13 @@ import os
 import inspect
 from typing import Any, Dict, List
 
+# Only show calibrations flagged for printing
+# The API expects the filter as a list of objects in the ``filter`` query
+# parameter.
+DEFAULT_FILTER: List[Dict[str, Any]] = [
+    {"property": "C2339", "value": 1, "operator": "="}
+]
+
 from PIL import Image
 from nicegui import ui
 
@@ -115,7 +122,7 @@ def main() -> None:
                 username.value,
                 password.value,
                 api_key.value,
-                {},
+                DEFAULT_FILTER,
             )
             stored_login.update(
                 {
@@ -147,7 +154,7 @@ def main() -> None:
                 stored_login.get("username", username.value),
                 stored_login.get("password", password.value),
                 stored_login.get("api_key", api_key.value),
-                {},
+                DEFAULT_FILTER,
             )
             if isinstance(data, dict) and isinstance(data.get("data"), dict):
                 cal_list = data["data"].get("calibration", [])
@@ -157,6 +164,8 @@ def main() -> None:
                 cal_list = [data] if data else []
             rows = []
             for entry in cal_list:
+                if entry.get("C2339") != 1:
+                    continue
                 inv = entry.get("inventory") or {}
                 rows.append(
                     {

--- a/tests/test_calserver_api.py
+++ b/tests/test_calserver_api.py
@@ -1,5 +1,6 @@
 import builtins
 import importlib
+import json
 from types import SimpleNamespace
 
 import sys
@@ -33,4 +34,5 @@ def test_fetch_calibration_data():
     )
     assert data["result"] == "ok"
     assert data["params"]["HTTP_X_REST_USERNAME"] == "user"
-    assert data["json"] == {"foo": 1}
+    assert data["params"]["filter"] == json.dumps({"foo": 1})
+    assert data["json"] is None


### PR DESCRIPTION
## Summary
- restrict API calls to items flagged with `C2339 == 1`
- ignore non‑flagged entries when building the table
- send filter via query string instead of JSON body

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848276eb7b0832b8d63bc16acc2c228