### PR TITLE
Add API call example

### DIFF
--- a/examples/fetch_calibration.py
+++ b/examples/fetch_calibration.py
@@ -1,0 +1,15 @@
+import json
+from app.calserver_api import fetch_calibration_data
+
+BASE_URL = "https://{{DOMAIN}}"  # replace with your calServer URL
+USERNAME = "{{HTTP_X_REST_USERNAME}}"
+PASSWORD = "{{HTTP_X_REST_PASSWORD}}"
+API_KEY = "{{HTTP_X_REST_API_KEY}}"
+
+FILTER = [
+    {"property": "C2339", "value": "1", "operator": "="},
+]
+
+if __name__ == "__main__":
+    data = fetch_calibration_data(BASE_URL, USERNAME, PASSWORD, API_KEY, FILTER)
+    print(json.dumps(data, indent=2))


### PR DESCRIPTION
## Summary
- add `examples/fetch_calibration.py` showing how to call the API with the default calibration filter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68482ad9cb10832b8190cb3579124ff8