### PR TITLE
Add SVG label preview

### DIFF
--- a/app/label_templates.py
+++ b/app/label_templates.py
@@ -1,6 +1,8 @@
 """Functions for rendering device and calibration label images."""
 
 from PIL import Image, ImageDraw, ImageFont
+import base64
+import io
 from .qrcode_utils import generate_qr_code
 
 FONT = ImageFont.load_default()
@@ -29,6 +31,25 @@ def device_label(name: str, expiry: str, mtag: str) -> Image.Image:
     qr = generate_qr_code(mtag, size=100)
     img.paste(qr, (280, 10))
     return img
+
+
+def device_label_svg(name: str, expiry: str, mtag: str) -> str:
+    """Return an SVG representation of a device label."""
+
+    qr = generate_qr_code(mtag, size=100)
+    buffer = io.BytesIO()
+    qr.save(buffer, format="PNG")
+    qr_b64 = base64.b64encode(buffer.getvalue()).decode()
+
+    svg = f"""
+<svg width='400' height='200' xmlns='http://www.w3.org/2000/svg'>
+  <rect width='100%' height='100%' fill='white'/>
+  <text x='10' y='30' font-size='16'>Gerät: {name}</text>
+  <text x='10' y='70' font-size='16'>Ablauf: {expiry}</text>
+  <image href='data:image/png;base64,{qr_b64}' x='280' y='10' width='100' height='100'/>
+</svg>
+"""
+    return svg
 
 
 def calibration_label(date: str, status: str, cert: str, qr_data: str) -> Image.Image:

--- a/app/main.py
+++ b/app/main.py
@@ -14,11 +14,11 @@ from nicegui import ui
 
 try:
     from .calserver_api import fetch_calibration_data
-    from .label_templates import device_label
+    from .label_templates import device_label, device_label_svg
     from .print_utils import print_label
 except ImportError:  # pragma: no cover - running as script
     from calserver_api import fetch_calibration_data
-    from label_templates import device_label
+    from label_templates import device_label, device_label_svg
     from print_utils import print_label
 
 
@@ -93,6 +93,7 @@ def main() -> None:
 
     status_log: ui.log | None = None
     label_img: ui.image | None = None
+    label_svg: ui.html | None = None
     print_button: ui.button | None = None
     label_card: ui.card | None = None
     placeholder_label: ui.label | None = None
@@ -212,6 +213,9 @@ def main() -> None:
             if label_img:
                 label_img.set_source("")
                 label_img.visible = False
+            if label_svg:
+                label_svg.content = ""
+                label_svg.visible = False
             if placeholder_label:
                 placeholder_label.visible = True
             if print_button:
@@ -228,6 +232,9 @@ def main() -> None:
         if label_img:
             label_img.set_source(_pil_to_data_url(img))
             label_img.visible = True
+        if label_svg:
+            label_svg.content = device_label_svg(name, expiry, mtag)
+            label_svg.visible = True
         if placeholder_label:
             placeholder_label.visible = False
         if print_button:
@@ -258,7 +265,7 @@ def main() -> None:
             push_status(f"Print error: {e}")
 
     def show_main_ui() -> None:
-        nonlocal status_log, label_img, print_button, label_card, device_table, main_layout, empty_table_label, placeholder_label, filter_slider
+        nonlocal status_log, label_img, label_svg, print_button, label_card, device_table, main_layout, empty_table_label, placeholder_label, filter_slider
         main_layout = ui.column()
         with main_layout:
             ui.button("Logout", on_click=logout).classes("absolute-top-right q-mt-sm q-mr-sm").props("icon=logout flat color=negative")
@@ -275,8 +282,9 @@ def main() -> None:
                     with label_card:
                         ui.label("Label-Vorschau").classes("text-h6")
                         placeholder_label = ui.label("Keine Vorschau verfügbar").classes("text-grey q-mb-md")
-                        label_img = ui.image("").classes("q-mb-md").style("max-width:260px;")
-                        label_img.visible = False
+                        label_svg = ui.html("", sanitize=False).classes("q-mb-md").style("max-width:260px;")
+                        label_svg.visible = False
+                        label_img = ui.image("").style("display:none;")
                         print_button = ui.button("Drucken", on_click=do_print).props("color=primary")
                         print_button.disable()
         footer = ui.footer().classes("bg-grey-2 shadow-2")

--- a/tests/test_label_templates.py
+++ b/tests/test_label_templates.py
@@ -13,6 +13,9 @@ class DummyImage:
     def paste(self, img, position):
         self.pasted.append((img, position))
 
+    def save(self, buffer, format=None):
+        buffer.write(b"dummy")
+
 
 def new(mode, size, color="white"):
     return DummyImage(size=size, color=color)
@@ -89,3 +92,11 @@ def test_calibration_label_contents():
     assert "Date: 2023-01-01" in texts[0]
     assert "Status: OK" in texts[1]
     assert "Cert: C123" in texts[2]
+
+
+def test_device_label_svg_contents():
+    svg = label_templates.device_label_svg("Device", "2025-01-01", "MT123")
+    assert "<svg" in svg
+    assert "Gerät: Device" in svg
+    assert "Ablauf: 2025-01-01" in svg
+    assert "data:image/png;base64" in svg


### PR DESCRIPTION
## Summary
- render a device label preview as SVG
- show the SVG preview in NiceGUI
- cover new functionality with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684832a0e4d4832b8dc6fadac55db05d