### PR TITLE
Add SVG QR code generation support

### DIFF
--- a/app/label_templates.py
+++ b/app/label_templates.py
@@ -1,9 +1,7 @@
 """Functions for rendering device and calibration label images."""
 
 from PIL import Image, ImageDraw, ImageFont
-import base64
-import io
-from .qrcode_utils import generate_qr_code
+from .qrcode_utils import generate_qr_code, generate_qr_code_svg
 
 FONT = ImageFont.load_default()
 
@@ -36,17 +34,16 @@ def device_label(name: str, expiry: str, mtag: str) -> Image.Image:
 def device_label_svg(name: str, expiry: str, mtag: str) -> str:
     """Return an SVG representation of a device label."""
 
-    qr = generate_qr_code(mtag, size=100)
-    buffer = io.BytesIO()
-    qr.save(buffer, format="PNG")
-    qr_b64 = base64.b64encode(buffer.getvalue()).decode()
+    qr_svg = generate_qr_code_svg(mtag)
 
     svg = f"""
 <svg width='400' height='200' xmlns='http://www.w3.org/2000/svg'>
   <rect width='100%' height='100%' fill='white'/>
   <text x='10' y='30' font-size='16'>Gerät: {name}</text>
   <text x='10' y='70' font-size='16'>Ablauf: {expiry}</text>
-  <image href='data:image/png;base64,{qr_b64}' x='280' y='10' width='100' height='100'/>
+  <g transform='translate(280,10)'>
+    {qr_svg}
+  </g>
 </svg>
 """
     return svg

--- a/app/qrcode_utils.py
+++ b/app/qrcode_utils.py
@@ -1,7 +1,9 @@
 """Utility helpers for creating QR codes as images."""
 
 import qrcode
+import qrcode.image.svg
 from PIL import Image
+import io
 
 
 def generate_qr_code(data: str, size: int = 200) -> Image.Image:
@@ -26,3 +28,15 @@ def generate_qr_code(data: str, size: int = 200) -> Image.Image:
     qr.make(fit=True)
     img = qr.make_image(fill_color="black", back_color="white")
     return img.resize((size, size))
+
+
+def generate_qr_code_svg(data: str) -> str:
+    """Return an SVG string for ``data`` encoded as QR code."""
+
+    qr = qrcode.QRCode(box_size=10, border=2)
+    qr.add_data(data)
+    qr.make(fit=True)
+    img = qr.make_image(image_factory=qrcode.image.svg.SvgImage)
+    buffer = io.BytesIO()
+    img.save(buffer)
+    return buffer.getvalue().decode()

--- a/examples/svg_label_example.py
+++ b/examples/svg_label_example.py
@@ -1,0 +1,33 @@
+from nicegui import ui
+import requests
+import qrcode
+import io
+import qrcode.image.svg
+
+# 1) API abfragen
+response = requests.get('https://api.example.com/auswertung')
+data = response.json()
+value_i4201 = data.get('I4201', '—')
+value_c2303 = data.get('C2303', '—')
+
+# 2) QR-Code als SVG generieren
+factory = qrcode.image.svg.SvgImage
+qr = qrcode.make('MTAG', image_factory=factory)
+buf = io.BytesIO()
+qr.save(buf)
+qr_svg = buf.getvalue().decode()
+
+# 3) SVG-Template zusammenbauen
+svg_template = f'''
+<svg viewBox="0 0 350 200" width="350" height="200" xmlns="http://www.w3.org/2000/svg">
+  <g transform="translate(10,10) scale(0.8)">
+    {qr_svg}
+  </g>
+  <text x="200" y="60" font-family="Arial" font-size="16">I4201: {value_i4201}</text>
+  <text x="200" y="100" font-family="Arial" font-size="16">C2303: {value_c2303}</text>
+</svg>'''
+
+# 4) in NiceGUI einbetten
+ui.html(svg_template)
+
+ui.run()

--- a/tests/test_label_templates.py
+++ b/tests/test_label_templates.py
@@ -61,7 +61,11 @@ class DummyQR(DummyImage):
 def generate_qr_code(data, size=200):
     return DummyQR(data, size)
 
+def generate_qr_code_svg(data):
+    return '<svg></svg>'
+
 qr_mod.generate_qr_code = generate_qr_code
+qr_mod.generate_qr_code_svg = generate_qr_code_svg
 sys.modules["app.qrcode_utils"] = qr_mod
 
 label_templates = importlib.import_module("app.label_templates")
@@ -99,4 +103,4 @@ def test_device_label_svg_contents():
     assert "<svg" in svg
     assert "Gerät: Device" in svg
     assert "Ablauf: 2025-01-01" in svg
-    assert "data:image/png;base64" in svg
+    assert "<g" in svg

--- a/tests/test_qrcode_utils.py
+++ b/tests/test_qrcode_utils.py
@@ -19,9 +19,21 @@ def _stub_modules():
             self.data = data
         def make(self, fit=True):
             pass
-        def make_image(self, fill_color='black', back_color='white'):
+        def make_image(self, fill_color='black', back_color='white', image_factory=None):
+            if image_factory:
+                return image_factory()
             return DummyImage()
     qrcode_mod.QRCode = DummyQRCode
+
+    # Stub qrcode.image.svg.SvgImage
+    qrcode_image_mod = types.ModuleType('qrcode.image')
+    qrcode_svg_mod = types.ModuleType('qrcode.image.svg')
+    class DummySvgImage:
+        def save(self, buffer):
+            buffer.write(b'<svg></svg>')
+    qrcode_svg_mod.SvgImage = DummySvgImage
+    qrcode_image_mod.svg = qrcode_svg_mod
+    qrcode_mod.image = qrcode_image_mod
 
     pil_mod = types.ModuleType('PIL')
     pil_image_mod = types.ModuleType('PIL.Image')
@@ -40,3 +52,8 @@ qrcode_utils = importlib.import_module('app.qrcode_utils')
 def test_generate_qr_code_size():
     img = qrcode_utils.generate_qr_code('hello', size=100)
     assert img.size == (100, 100)
+
+
+def test_generate_qr_code_svg_string():
+    svg = qrcode_utils.generate_qr_code_svg('hello')
+    assert '<svg' in svg and '</svg>' in svg


### PR DESCRIPTION
## Summary
- add `generate_qr_code_svg` helper
- embed vector QR code in `device_label_svg`
- update tests for new QR code helper
- provide NiceGUI example that combines API data and SVG QR

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684847f2e4c0832bb69d2c4caa98fbf7