### PR TITLE
Add standard SVG header

### DIFF
--- a/app/label_templates.py
+++ b/app/label_templates.py
@@ -3,6 +3,16 @@
 from PIL import Image, ImageDraw, ImageFont
 from .qrcode_utils import generate_qr_code, generate_qr_code_svg
 
+
+def svg_header() -> str:
+    """Return a standard SVG header."""
+
+    return (
+        "<?xml version='1.0' encoding='UTF-8' standalone='no'?>\n"
+        "<!DOCTYPE svg PUBLIC '-//W3C//DTD SVG 1.1//EN' "
+        "'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'>\n"
+    )
+
 FONT = ImageFont.load_default()
 
 
@@ -35,8 +45,7 @@ def device_label_svg(name: str, expiry: str, mtag: str) -> str:
     """Return an SVG representation of a device label."""
 
     qr_svg = generate_qr_code_svg(mtag)
-
-    svg = f"""
+    svg_body = f"""
 <svg width='400' height='200' xmlns='http://www.w3.org/2000/svg'>
   <rect width='100%' height='100%' fill='white'/>
   <text x='10' y='30' font-size='16'>Gerät: {name}</text>
@@ -46,15 +55,14 @@ def device_label_svg(name: str, expiry: str, mtag: str) -> str:
   </g>
 </svg>
 """
-    return svg
+    return svg_header() + svg_body
 
 
 def simple_device_label_svg(name: str, expiry: str, mtag: str) -> str:
     """Return a simplified SVG representation of a device label."""
 
     qr_svg = generate_qr_code_svg(mtag)
-
-    svg = f"""
+    svg_body = f"""
 <svg width='400' height='200' xmlns='http://www.w3.org/2000/svg'>
   <rect width='100%' height='100%' fill='white'/>
   <text x='200' y='40' font-size='20' text-anchor='middle'>{name}</text>
@@ -64,7 +72,7 @@ def simple_device_label_svg(name: str, expiry: str, mtag: str) -> str:
   </g>
 </svg>
 """
-    return svg
+    return svg_header() + svg_body
 
 
 def calibration_label(date: str, status: str, cert: str, qr_data: str) -> Image.Image:

--- a/app/main.py
+++ b/app/main.py
@@ -20,6 +20,7 @@ try:
         device_label_svg,
         available_label_templates,
         render_label_template,
+        svg_header,
     )
     from .qrcode_utils import generate_qr_code, generate_qr_code_svg
     from .print_utils import print_label, list_printers
@@ -30,6 +31,7 @@ except ImportError:
         device_label_svg,
         available_label_templates,
         render_label_template,
+        svg_header,
     )
     from qrcode_utils import generate_qr_code, generate_qr_code_svg
     from print_utils import print_label, list_printers
@@ -158,7 +160,8 @@ def main() -> None:
         qr_svg = generate_qr_code_svg(qr_data)
         if template in jinja_templates:
             tpl = jinja2.Template(jinja_templates[template])
-            return tpl.render(I4201=name, C2303=expiry, MTAG=qr_data, QRCODE=qr_svg)
+            body = tpl.render(I4201=name, C2303=expiry, MTAG=qr_data, QRCODE=qr_svg)
+            return svg_header() + body
         return render_label_template(template, name, expiry, qr_data)
 
     # enable Tailwind CSS for the login dialog styling

--- a/tests/test_label_templates.py
+++ b/tests/test_label_templates.py
@@ -104,3 +104,8 @@ def test_device_label_svg_contents():
     assert "Gerät: Device" in svg
     assert "Ablauf: 2025-01-01" in svg
     assert "<g" in svg
+
+
+def test_svg_header_present():
+    svg = label_templates.device_label_svg("Device", "2025-01-01", "MT123")
+    assert svg.startswith(label_templates.svg_header())


### PR DESCRIPTION
## Summary
- add `svg_header` helper to `label_templates`
- prepend header to label SVG functions
- import and use header when rendering Jinja2 templates
- test that the header is present

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848af438f7c832ba04f62a2991e5e2d