### PR TITLE
Fix QR code preview in SVG templates

### DIFF
--- a/app/qrcode_utils.py
+++ b/app/qrcode_utils.py
@@ -39,4 +39,7 @@ def generate_qr_code_svg(data: str) -> str:
     img = qr.make_image(image_factory=qrcode.image.svg.SvgImage)
     buffer = io.BytesIO()
     img.save(buffer)
-    return buffer.getvalue().decode()
+    svg = buffer.getvalue().decode()
+    if svg.lstrip().startswith("<?xml"):
+        svg = svg.split("?>", 1)[-1]
+    return svg

--- a/tests/test_qrcode_utils.py
+++ b/tests/test_qrcode_utils.py
@@ -57,3 +57,4 @@ def test_generate_qr_code_size():
 def test_generate_qr_code_svg_string():
     svg = qrcode_utils.generate_qr_code_svg('hello')
     assert '<svg' in svg and '</svg>' in svg
+    assert not svg.strip().startswith('<?xml'), 'XML header not removed'


### PR DESCRIPTION
## Summary
- strip the XML header when generating QR code SVG strings
- ensure tests verify absence of XML header

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848ada317e0832ba917ebc712f3b443