### PR TITLE
Add cairosvg dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Ziel des Projektes ist es, das Erstellen von Kalibrierungs- und Geraetebeschrift
    ```bash
    pip install -r requirements.txt
    ```
+   Das installiert auch optionale Bibliotheken wie **cairosvg**,
+   die fuer PDF- oder PNG-Druck benoetigt werden.
 3. (Optional) Node-Umgebung fuer die Desktop-Version einrichten:
    ```bash
    cd electron

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ requests
 pillow
 qrcode
 jinja2
+cairosvg
 pywin32; sys_platform == "win32"
 pycups; sys_platform != "win32"
 pytest


### PR DESCRIPTION
## Summary
- add cairosvg package to `requirements.txt`
- document cairoSVG dependency in install instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848b3259ab4832ba576327961014f96