### PR TITLE
Replace CairoSVG with svglib conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ Ziel des Projektes ist es, das Erstellen von Kalibrierungs- und Geraetebeschrift
    ```bash
    pip install -r requirements.txt
    ```
-   Das installiert auch optionale Bibliotheken wie **cairosvg**,
-   die fuer PDF- oder PNG-Druck benoetigt werden.
+   Das installiert auch optionale Bibliotheken wie **svglib** und
+   **reportlab**, die zur Konvertierung von SVG in PNG oder PDF genutzt
+   werden.
 3. (Optional) Node-Umgebung fuer die Desktop-Version einrichten:
    ```bash
    cd electron

--- a/app/main.py
+++ b/app/main.py
@@ -374,26 +374,20 @@ def main() -> None:
         try:
             if pdf_option and pdf_option.value:
                 import tempfile
-                import cairosvg
+                from .svg_utils import svg_to_pdf_bytes
                 from .print_utils import print_file
+                pdf_data = svg_to_pdf_bytes(current_svg)
                 with tempfile.NamedTemporaryFile(delete=False, suffix='.pdf') as tmp:
+                    tmp.write(pdf_data)
                     tmp_path = tmp.name
-                cairosvg.svg2pdf(bytestring=current_svg.encode('utf-8'), write_to=tmp_path)
                 try:
                     print_file(tmp_path, selected_printer)
                 finally:
                     os.unlink(tmp_path)
             elif png_option and png_option.value:
-                import tempfile
-                import cairosvg
-                with tempfile.NamedTemporaryFile(delete=False, suffix='.png') as tmp:
-                    tmp_path = tmp.name
-                cairosvg.svg2png(bytestring=current_svg.encode('utf-8'), write_to=tmp_path)
-                img = Image.open(tmp_path)
-                try:
-                    print_label(img, selected_printer)
-                finally:
-                    os.unlink(tmp_path)
+                from .svg_utils import svg_to_png_image
+                img = svg_to_png_image(current_svg)
+                print_label(img, selected_printer)
             else:
                 print_label(current_image, selected_printer)
             push_status(f"Printed on: {selected_printer}")

--- a/app/svg_utils.py
+++ b/app/svg_utils.py
@@ -1,0 +1,23 @@
+import io
+
+
+def svg_to_png_image(svg_string: str):
+    """Return a PIL Image from an SVG string."""
+    from svglib.svglib import svg2rlg
+    from reportlab.graphics import renderPM
+    drawing = svg2rlg(io.StringIO(svg_string))
+    return renderPM.drawToPIL(drawing)
+
+
+def svg_to_pdf_bytes(svg_string: str) -> bytes:
+    """Return PDF bytes created from the given SVG string."""
+    from svglib.svglib import svg2rlg
+    from reportlab.graphics import renderPDF
+    drawing = svg2rlg(io.StringIO(svg_string))
+    try:
+        pdf_bytes = renderPDF.drawToString(drawing)
+    except AttributeError:  # fallback for older versions
+        buffer = io.BytesIO()
+        renderPDF.drawToFile(drawing, buffer)
+        pdf_bytes = buffer.getvalue()
+    return pdf_bytes

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ requests
 pillow
 qrcode
 jinja2
-cairosvg
+svglib
+reportlab
 pywin32; sys_platform == "win32"
 pycups; sys_platform != "win32"
 pytest


### PR DESCRIPTION
## Summary
- switch SVG conversion from CairoSVG to svglib/reportlab
- update print logic to use svglib based conversions
- add `svg_utils` module
- document new dependencies
- update requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848b5b2b7c4832bb98e6d10d3621af4