### PR TITLE
Use PNG QR codes in preview

### DIFF
--- a/app/label_templates.py
+++ b/app/label_templates.py
@@ -1,7 +1,10 @@
 """Functions for rendering device and calibration label images."""
 
 from PIL import Image, ImageDraw, ImageFont
-from .qrcode_utils import generate_qr_code, generate_qr_code_svg
+from .qrcode_utils import (
+    generate_qr_code,
+    generate_qr_code_data_url,
+)
 
 
 def svg_header() -> str:
@@ -43,14 +46,15 @@ def device_label(name: str, expiry: str, mtag: str) -> Image.Image:
 def device_label_svg(name: str, expiry: str, mtag: str) -> str:
     """Return an SVG representation of a device label."""
 
-    qr_svg = generate_qr_code_svg(mtag)
+    qr_png = generate_qr_code_data_url(mtag, size=100)
+    qr_elem = f"<image href='{qr_png}' width='100' height='100' />"
     svg_body = f"""
 <svg width='400' height='200' xmlns='http://www.w3.org/2000/svg'>
   <rect width='100%' height='100%' fill='white'/>
   <text x='10' y='30' font-size='16'>Gerät: {name}</text>
   <text x='10' y='70' font-size='16'>Ablauf: {expiry}</text>
   <g transform='translate(280,10)'>
-    {qr_svg}
+    {qr_elem}
   </g>
 </svg>
 """
@@ -60,14 +64,15 @@ def device_label_svg(name: str, expiry: str, mtag: str) -> str:
 def simple_device_label_svg(name: str, expiry: str, mtag: str) -> str:
     """Return a simplified SVG representation of a device label."""
 
-    qr_svg = generate_qr_code_svg(mtag)
+    qr_png = generate_qr_code_data_url(mtag, size=100)
+    qr_elem = f"<image href='{qr_png}' width='100' height='100' />"
     svg_body = f"""
 <svg width='400' height='200' xmlns='http://www.w3.org/2000/svg'>
   <rect width='100%' height='100%' fill='white'/>
   <text x='200' y='40' font-size='20' text-anchor='middle'>{name}</text>
   <text x='200' y='80' font-size='14' text-anchor='middle'>Bis: {expiry}</text>
   <g transform='translate(150,90)'>
-    {qr_svg}
+    {qr_elem}
   </g>
 </svg>
 """

--- a/app/main.py
+++ b/app/main.py
@@ -22,7 +22,10 @@ try:
         render_label_template,
         svg_header,
     )
-    from .qrcode_utils import generate_qr_code, generate_qr_code_svg
+    from .qrcode_utils import (
+        generate_qr_code,
+        generate_qr_code_data_url,
+    )
     from .print_utils import print_label, list_printers, print_file
 except ImportError:
     from calserver_api import fetch_calibration_data
@@ -33,7 +36,10 @@ except ImportError:
         render_label_template,
         svg_header,
     )
-    from qrcode_utils import generate_qr_code, generate_qr_code_svg
+    from qrcode_utils import (
+        generate_qr_code,
+        generate_qr_code_data_url,
+    )
     from print_utils import print_label, list_printers, print_file
 
 
@@ -160,10 +166,11 @@ def main() -> None:
     }
 
     def render_preview(template: str, name: str, expiry: str, qr_data: str) -> str:
-        qr_svg = generate_qr_code_svg(qr_data)
+        qr_png = generate_qr_code_data_url(qr_data, size=200)
+        qr_elem = f"<image href='{qr_png}' width='200' height='200' />"
         if template in jinja_templates:
             tpl = jinja2.Template(jinja_templates[template])
-            body = tpl.render(I4201=name, C2303=expiry, MTAG=qr_data, QRCODE=qr_svg)
+            body = tpl.render(I4201=name, C2303=expiry, MTAG=qr_data, QRCODE=qr_elem)
             return svg_header() + body
         return render_label_template(template, name, expiry, qr_data)
 

--- a/app/qrcode_utils.py
+++ b/app/qrcode_utils.py
@@ -4,6 +4,7 @@ import qrcode
 import qrcode.image.svg
 from PIL import Image
 import io
+import base64
 
 
 def generate_qr_code(data: str, size: int = 200) -> Image.Image:
@@ -43,3 +44,13 @@ def generate_qr_code_svg(data: str) -> str:
     if svg.lstrip().startswith("<?xml"):
         svg = svg.split("?>", 1)[-1]
     return svg
+
+
+def generate_qr_code_data_url(data: str, size: int = 200) -> str:
+    """Return a PNG data URL for ``data`` encoded as QR code."""
+
+    img = generate_qr_code(data, size=size)
+    buffer = io.BytesIO()
+    img.save(buffer, format="PNG")
+    encoded = base64.b64encode(buffer.getvalue()).decode()
+    return f"data:image/png;base64,{encoded}"

--- a/tests/test_label_templates.py
+++ b/tests/test_label_templates.py
@@ -64,8 +64,12 @@ def generate_qr_code(data, size=200):
 def generate_qr_code_svg(data):
     return '<svg></svg>'
 
+def generate_qr_code_data_url(data, size=200):
+    return f'data:image/png;base64,{data}'
+
 qr_mod.generate_qr_code = generate_qr_code
 qr_mod.generate_qr_code_svg = generate_qr_code_svg
+qr_mod.generate_qr_code_data_url = generate_qr_code_data_url
 sys.modules["app.qrcode_utils"] = qr_mod
 
 label_templates = importlib.import_module("app.label_templates")

--- a/tests/test_qrcode_utils.py
+++ b/tests/test_qrcode_utils.py
@@ -9,6 +9,8 @@ class DummyImage:
     def resize(self, size):
         self.size = size
         return self
+    def save(self, buffer, format=None):
+        buffer.write(b'PNG')
 
 def _stub_modules():
     qrcode_mod = types.ModuleType('qrcode')
@@ -58,3 +60,8 @@ def test_generate_qr_code_svg_string():
     svg = qrcode_utils.generate_qr_code_svg('hello')
     assert '<svg' in svg and '</svg>' in svg
     assert not svg.strip().startswith('<?xml'), 'XML header not removed'
+
+
+def test_generate_qr_code_data_url_prefix():
+    url = qrcode_utils.generate_qr_code_data_url('hello', size=100)
+    assert url.startswith('data:image/png;base64,')


### PR DESCRIPTION
## Summary
- provide `generate_qr_code_data_url` helper
- render QR codes as PNG in label templates and preview
- adjust tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848c0671058832b96342afbbae4fdbc