### PR TITLE
Handle invalid SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ Ziel des Projektes ist es, das Erstellen von Kalibrierungs- und Geraetebeschrift
    ```bash
    pip install -r requirements.txt
    ```
-   Das installiert auch optionale Bibliotheken wie **cairosvg**,
-   die fuer PDF- oder PNG-Druck benoetigt werden.
+   Das installiert auch optionale Bibliotheken wie **svglib** und
+   **reportlab**, die zur Konvertierung von SVG in PNG oder PDF genutzt
+   werden.
 3. (Optional) Node-Umgebung fuer die Desktop-Version einrichten:
    ```bash
    cd electron

--- a/app/label_templates.py
+++ b/app/label_templates.py
@@ -1,17 +1,17 @@
 """Functions for rendering device and calibration label images."""
 
 from PIL import Image, ImageDraw, ImageFont
+from html import escape
 from .qrcode_utils import generate_qr_code, generate_qr_code_svg
 
 
 def svg_header() -> str:
     """Return a standard SVG header."""
 
-    return (
-        "<?xml version='1.0' encoding='UTF-8' standalone='no'?>\n"
-        "<!DOCTYPE svg PUBLIC '-//W3C//DTD SVG 1.1//EN' "
-        "'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'>\n"
-    )
+    # ``svglib`` sometimes tries to load the external DTD referenced by the
+    # standard SVG doctype which can fail in restricted environments.  A minimal
+    # XML header is sufficient and avoids that network request.
+    return "<?xml version='1.0' encoding='UTF-8' standalone='no'?>\n"
 
 FONT = ImageFont.load_default()
 
@@ -48,8 +48,8 @@ def device_label_svg(name: str, expiry: str, mtag: str) -> str:
     svg_body = f"""
 <svg width='400' height='200' xmlns='http://www.w3.org/2000/svg'>
   <rect width='100%' height='100%' fill='white'/>
-  <text x='10' y='30' font-size='16'>Gerät: {name}</text>
-  <text x='10' y='70' font-size='16'>Ablauf: {expiry}</text>
+  <text x='10' y='30' font-size='16'>Gerät: {escape(name)}</text>
+  <text x='10' y='70' font-size='16'>Ablauf: {escape(expiry)}</text>
   <g transform='translate(280,10)'>
     {qr_svg}
   </g>
@@ -65,8 +65,8 @@ def simple_device_label_svg(name: str, expiry: str, mtag: str) -> str:
     svg_body = f"""
 <svg width='400' height='200' xmlns='http://www.w3.org/2000/svg'>
   <rect width='100%' height='100%' fill='white'/>
-  <text x='200' y='40' font-size='20' text-anchor='middle'>{name}</text>
-  <text x='200' y='80' font-size='14' text-anchor='middle'>Bis: {expiry}</text>
+  <text x='200' y='40' font-size='20' text-anchor='middle'>{escape(name)}</text>
+  <text x='200' y='80' font-size='14' text-anchor='middle'>Bis: {escape(expiry)}</text>
   <g transform='translate(150,90)'>
     {qr_svg}
   </g>

--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,7 @@ import inspect
 from typing import Any, Dict, List
 
 import jinja2
+from html import escape
 
 from PIL import Image
 from nicegui import ui
@@ -163,7 +164,12 @@ def main() -> None:
         qr_svg = generate_qr_code_svg(qr_data)
         if template in jinja_templates:
             tpl = jinja2.Template(jinja_templates[template])
-            body = tpl.render(I4201=name, C2303=expiry, MTAG=qr_data, QRCODE=qr_svg)
+            body = tpl.render(
+                I4201=escape(name),
+                C2303=escape(expiry),
+                MTAG=escape(qr_data),
+                QRCODE=qr_svg,
+            )
             return svg_header() + body
         return render_label_template(template, name, expiry, qr_data)
 
@@ -374,26 +380,20 @@ def main() -> None:
         try:
             if pdf_option and pdf_option.value:
                 import tempfile
-                import cairosvg
+                from .svg_utils import svg_to_pdf_bytes
                 from .print_utils import print_file
+                pdf_data = svg_to_pdf_bytes(current_svg)
                 with tempfile.NamedTemporaryFile(delete=False, suffix='.pdf') as tmp:
+                    tmp.write(pdf_data)
                     tmp_path = tmp.name
-                cairosvg.svg2pdf(bytestring=current_svg.encode('utf-8'), write_to=tmp_path)
                 try:
                     print_file(tmp_path, selected_printer)
                 finally:
                     os.unlink(tmp_path)
             elif png_option and png_option.value:
-                import tempfile
-                import cairosvg
-                with tempfile.NamedTemporaryFile(delete=False, suffix='.png') as tmp:
-                    tmp_path = tmp.name
-                cairosvg.svg2png(bytestring=current_svg.encode('utf-8'), write_to=tmp_path)
-                img = Image.open(tmp_path)
-                try:
-                    print_label(img, selected_printer)
-                finally:
-                    os.unlink(tmp_path)
+                from .svg_utils import svg_to_png_image
+                img = svg_to_png_image(current_svg)
+                print_label(img, selected_printer)
             else:
                 print_label(current_image, selected_printer)
             push_status(f"Printed on: {selected_printer}")

--- a/app/svg_utils.py
+++ b/app/svg_utils.py
@@ -1,0 +1,27 @@
+import io
+
+
+def svg_to_png_image(svg_string: str):
+    """Return a PIL Image from an SVG string."""
+    from svglib.svglib import svg2rlg
+    from reportlab.graphics import renderPM
+    drawing = svg2rlg(io.StringIO(svg_string))
+    if drawing is None:
+        raise ValueError("Invalid SVG data")
+    return renderPM.drawToPIL(drawing)
+
+
+def svg_to_pdf_bytes(svg_string: str) -> bytes:
+    """Return PDF bytes created from the given SVG string."""
+    from svglib.svglib import svg2rlg
+    from reportlab.graphics import renderPDF
+    drawing = svg2rlg(io.StringIO(svg_string))
+    if drawing is None:
+        raise ValueError("Invalid SVG data")
+    try:
+        pdf_bytes = renderPDF.drawToString(drawing)
+    except AttributeError:  # fallback for older versions
+        buffer = io.BytesIO()
+        renderPDF.drawToFile(drawing, buffer)
+        pdf_bytes = buffer.getvalue()
+    return pdf_bytes

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ requests
 pillow
 qrcode
 jinja2
-cairosvg
+svglib
+reportlab
 pywin32; sys_platform == "win32"
 pycups; sys_platform != "win32"
 pytest

--- a/tests/test_svg_utils.py
+++ b/tests/test_svg_utils.py
@@ -1,0 +1,62 @@
+import importlib
+import sys
+import types
+import pytest
+
+
+def _load_svg_utils(return_drawing=True, has_draw_to_string=True):
+    # Setup stub modules for svglib
+    svglib_mod = types.ModuleType('svglib')
+    svglib_svglib_mod = types.ModuleType('svglib.svglib')
+    def dummy_svg2rlg(src):
+        return object() if return_drawing else None
+    svglib_svglib_mod.svg2rlg = dummy_svg2rlg
+    svglib_mod.svglib = svglib_svglib_mod
+    sys.modules['svglib'] = svglib_mod
+    sys.modules['svglib.svglib'] = svglib_svglib_mod
+
+    # Setup stub modules for reportlab
+    reportlab_mod = types.ModuleType('reportlab')
+    graphics_mod = types.ModuleType('reportlab.graphics')
+    renderPM_mod = types.ModuleType('reportlab.graphics.renderPM')
+    renderPDF_mod = types.ModuleType('reportlab.graphics.renderPDF')
+    renderPM_mod.drawToPIL = lambda drawing: ('PNG', drawing)
+    if has_draw_to_string:
+        renderPDF_mod.drawToString = lambda drawing: b'PDF'
+    else:
+        def drawToFile(drawing, buffer):
+            buffer.write(b'PDF')
+        renderPDF_mod.drawToFile = drawToFile
+    graphics_mod.renderPM = renderPM_mod
+    graphics_mod.renderPDF = renderPDF_mod
+    reportlab_mod.graphics = graphics_mod
+    sys.modules['reportlab'] = reportlab_mod
+    sys.modules['reportlab.graphics'] = graphics_mod
+    sys.modules['reportlab.graphics.renderPM'] = renderPM_mod
+    sys.modules['reportlab.graphics.renderPDF'] = renderPDF_mod
+
+    if 'app.svg_utils' in sys.modules:
+        return importlib.reload(sys.modules['app.svg_utils'])
+    return importlib.import_module('app.svg_utils')
+
+
+def test_svg_to_png_image_success():
+    su = _load_svg_utils()
+    result = su.svg_to_png_image('<svg></svg>')
+    assert result[0] == 'PNG'
+
+
+def test_svg_to_png_image_invalid():
+    su = _load_svg_utils(return_drawing=False)
+    with pytest.raises(ValueError):
+        su.svg_to_png_image('<svg></svg>')
+
+
+def test_svg_to_pdf_bytes_default():
+    su = _load_svg_utils()
+    assert su.svg_to_pdf_bytes('<svg></svg>') == b'PDF'
+
+
+def test_svg_to_pdf_bytes_fallback():
+    su = _load_svg_utils(has_draw_to_string=False)
+    assert su.svg_to_pdf_bytes('<svg></svg>') == b'PDF'


### PR DESCRIPTION
## Summary
- validate SVG data before calling render
- add unit tests for svg_utils
- avoid downloading external DTD by stripping doctype from generated SVG
- escape user-provided text in SVG templates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848b5b2b7c4832bb98e6d10d3621af4